### PR TITLE
Versioned installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ before_script:
 script:
   - PYTHONPATH=. pytest --ignore=./integration --cov=. --cov-report xml:coverage.xml --cov-report term-missing
   - PYTHONPATH=. pytest -x -s ./integration
-  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sonar-scanner; fi'  # sonar only on non-PRs
+  # Run SonarQube only on non-PRs and when "SONAR_TOKEN" is defined
+  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" && $SONAR_TOKEN ]; then sonar-scanner; fi'
 after_success:
   # Code coverage, deploy to PyPI and, when uploading new version, do mutation testing
   - ./travis_success.sh

--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ Furthermore, you will need the Hyperledger Fabric utility binaries that can be i
 
 ### Unit tests
 
-Once you have all requirments installed, all the unit tests should pass:
+Once you have all requirments installed, all the unit tests should pass and provide full coverage:
 
-    PYTHONPATH=. pytest --cov=. --cov-report term-missing
+    PYTHONPATH=. pytest --ignore=./integration --cov=. --cov-report xml:coverage.xml --cov-report term-missing
+
+The integration tests should also pass:
+
+    PYTHONPATH=. pytest -x -s ./integration
 
 ## Usage
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,9 +25,9 @@ copyright = "2019, Alejandro (Sasha) Vicente Grabovetsky"
 author = "Alejandro (Sasha) Vicente Grabovetsky"
 
 # The short X.Y version
-version = "0.2"
+version = "0.3"
 # The full version, including alpha/beta/rc tags
-release = "0.2.11"
+release = "0.3.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/dev/nephos_config.yaml
+++ b/examples/dev/nephos_config.yaml
@@ -37,3 +37,12 @@ peers:
   channel_name: mychannel
   channel_profile: MyChannel
   secret_channel: hlf--channel
+# You can specify a particular version of a chart for each chart used, or use the latest by default
+versions:
+  postgres:
+  hlf-ca:
+  kafka:
+  hlf-ord:
+  hlf-couchdb:
+  hlf-peer:
+  hl-composer:

--- a/examples/dev/nephos_config.yaml
+++ b/examples/dev/nephos_config.yaml
@@ -39,7 +39,7 @@ peers:
   secret_channel: hlf--channel
 # You can specify a particular version of a chart for each chart used, or use the latest by default
 versions:
-  postgres:
+  postgresql:
   hlf-ca:
   kafka:
   hlf-ord:

--- a/examples/prod/nephos_config.yaml
+++ b/examples/prod/nephos_config.yaml
@@ -49,3 +49,12 @@ composer:
   name: hlc
   secret_bna: hlc--bna
   secret_connection: hlc--connection
+# You can specify a particular version of a chart for each chart used, or use the latest by default
+versions:
+  postgres:
+  hlf-ca:
+  kafka:
+  hlf-ord:
+  hlf-couchdb:
+  hlf-peer:
+  hl-composer:

--- a/examples/prod/nephos_config.yaml
+++ b/examples/prod/nephos_config.yaml
@@ -51,7 +51,7 @@ composer:
   secret_connection: hlc--connection
 # You can specify a particular version of a chart for each chart used, or use the latest by default
 versions:
-  postgres:
+  postgresql:
   hlf-ca:
   kafka:
   hlf-ord:

--- a/examples/qa/nephos_config.yaml
+++ b/examples/qa/nephos_config.yaml
@@ -49,7 +49,7 @@ composer:
   secret_connection: hlc--connection
 # You can specify a particular version of a chart for each chart used, or use the latest by default
 versions:
-  postgres:
+  postgresql:
   hlf-ca:
   kafka:
   hlf-ord:

--- a/examples/qa/nephos_config.yaml
+++ b/examples/qa/nephos_config.yaml
@@ -47,3 +47,12 @@ composer:
   name: hlc
   secret_bna: hlc--bna
   secret_connection: hlc--connection
+# You can specify a particular version of a chart for each chart used, or use the latest by default
+versions:
+  postgres:
+  hlf-ca:
+  kafka:
+  hlf-ord:
+  hlf-couchdb:
+  hlf-peer:
+  hl-composer:

--- a/nephos/composer/connection_template.py
+++ b/nephos/composer/connection_template.py
@@ -31,8 +31,8 @@ def define_orderers(orderer_names, orderer_hosts, domain=None):
     """Define orderers as connection objects.
 
         Args:
-            orderer_names (list): List of orderer names.
-            orderer_hosts (list): List of orderer hosts.
+            orderer_names (Iterable): List of orderer names.
+            orderer_hosts (Iterable): List of orderer hosts.
             domain (str): Domain used. Defaults to none.
 
         Returns:
@@ -52,8 +52,8 @@ def define_peers(peer_names, peer_hosts, organisation, domain=None):
     """Define peers as connection objects.
 
         Args:
-            peer_names (list): List of peer names.
-            peer_hosts (list): List of peer hosts.
+            peer_names (Iterable): List of peer names.
+            peer_hosts (Iterable): List of peer hosts.
             organisation (str): What organisation the peers belong to
             domain (str): Domain used. Defaults to none.
 

--- a/nephos/composer/install.py
+++ b/nephos/composer/install.py
@@ -126,6 +126,7 @@ def deploy_composer(opts, upgrade=False, verbose=False):
     else:
         preserve = (
             HelmPreserve(
+                peer_namespace,
                 "{}-hl-composer-rest".format(opts["composer"]["name"]),
                 "COMPOSER_APIKEY",
                 "rest.config.apiKey",

--- a/nephos/composer/install.py
+++ b/nephos/composer/install.py
@@ -18,7 +18,7 @@ from nephos.composer.connection_template import json_ct
 from nephos.fabric.crypto import admin_creds
 from nephos.fabric.utils import get_pod
 from nephos.fabric.settings import get_namespace
-from nephos.helpers.helm import HelmPreserve, helm_check, helm_install, helm_upgrade
+from nephos.helpers.helm import HelmPreserve, helm_check, helm_extra_vars, helm_install, helm_upgrade
 from nephos.helpers.k8s import (
     get_app_info,
     cm_create,
@@ -112,15 +112,17 @@ def deploy_composer(opts, upgrade=False, verbose=False):
     composer_connection(opts, verbose=verbose)
 
     # Start Composer
+    config_yaml = "{dir}/hl-composer/{release}.yaml".format(
+                dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
+            )
     if not upgrade:
+        extra_vars = helm_extra_vars(config_yaml=config_yaml)
         helm_install(
             opts["core"]["chart_repo"],
             "hl-composer",
             opts["composer"]["name"],
             peer_namespace,
-            config_yaml="{dir}/hl-composer/{release}.yaml".format(
-                dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
-            ),
+            extra_vars=extra_vars,
             verbose=verbose,
         )
     else:
@@ -132,15 +134,12 @@ def deploy_composer(opts, upgrade=False, verbose=False):
                 "rest.config.apiKey",
             ),
         )
+        extra_vars = helm_extra_vars(config_yaml=config_yaml, preserve=preserve)
         helm_upgrade(
             opts["core"]["chart_repo"],
             "hl-composer",
             opts["composer"]["name"],
-            peer_namespace,
-            config_yaml="{dir}/hl-composer/{release}.yaml".format(
-                dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
-            ),
-            preserve=preserve,
+            extra_vars=extra_vars,
             verbose=verbose,
         )
     helm_check("hl-composer", opts["composer"]["name"], peer_namespace, pod_num=3)

--- a/nephos/composer/install.py
+++ b/nephos/composer/install.py
@@ -18,7 +18,13 @@ from nephos.composer.connection_template import json_ct
 from nephos.fabric.crypto import admin_creds
 from nephos.fabric.utils import get_pod
 from nephos.fabric.settings import get_namespace, get_version
-from nephos.helpers.helm import HelmPreserve, helm_check, helm_extra_vars, helm_install, helm_upgrade
+from nephos.helpers.helm import (
+    HelmPreserve,
+    helm_check,
+    helm_extra_vars,
+    helm_install,
+    helm_upgrade,
+)
 from nephos.helpers.k8s import (
     get_app_info,
     cm_create,
@@ -114,8 +120,8 @@ def deploy_composer(opts, upgrade=False, verbose=False):
     # Start Composer
     version = get_version(opts, "hl-composer")
     config_yaml = "{dir}/hl-composer/{release}.yaml".format(
-                dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
-            )
+        dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
+    )
     if not upgrade:
         extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
         helm_install(
@@ -135,7 +141,9 @@ def deploy_composer(opts, upgrade=False, verbose=False):
                 "rest.config.apiKey",
             ),
         )
-        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml, preserve=preserve)
+        extra_vars = helm_extra_vars(
+            version=version, config_yaml=config_yaml, preserve=preserve
+        )
         helm_upgrade(
             opts["core"]["chart_repo"],
             "hl-composer",

--- a/nephos/composer/install.py
+++ b/nephos/composer/install.py
@@ -18,7 +18,7 @@ from nephos.composer.connection_template import json_ct
 from nephos.fabric.crypto import admin_creds
 from nephos.fabric.utils import get_pod
 from nephos.fabric.settings import get_namespace
-from nephos.helpers.helm import HelmPreserve, helm_install, helm_upgrade
+from nephos.helpers.helm import HelmPreserve, helm_check, helm_install, helm_upgrade
 from nephos.helpers.k8s import (
     get_app_info,
     cm_create,
@@ -118,7 +118,6 @@ def deploy_composer(opts, upgrade=False, verbose=False):
             "hl-composer",
             opts["composer"]["name"],
             peer_namespace,
-            pod_num=3,
             config_yaml="{dir}/hl-composer/{release}.yaml".format(
                 dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
             ),
@@ -137,13 +136,13 @@ def deploy_composer(opts, upgrade=False, verbose=False):
             "hl-composer",
             opts["composer"]["name"],
             peer_namespace,
-            pod_num=3,
             config_yaml="{dir}/hl-composer/{release}.yaml".format(
                 dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
             ),
             preserve=preserve,
             verbose=verbose,
         )
+    helm_check("hl-composer", opts["composer"]["name"], peer_namespace, pod_num=3)
 
 
 def setup_admin(opts, verbose=False):

--- a/nephos/composer/install.py
+++ b/nephos/composer/install.py
@@ -17,7 +17,7 @@ from kubernetes.client.rest import ApiException
 from nephos.composer.connection_template import json_ct
 from nephos.fabric.crypto import admin_creds
 from nephos.fabric.utils import get_pod
-from nephos.fabric.settings import get_namespace
+from nephos.fabric.settings import get_namespace, get_version
 from nephos.helpers.helm import HelmPreserve, helm_check, helm_extra_vars, helm_install, helm_upgrade
 from nephos.helpers.k8s import (
     get_app_info,
@@ -112,11 +112,12 @@ def deploy_composer(opts, upgrade=False, verbose=False):
     composer_connection(opts, verbose=verbose)
 
     # Start Composer
+    version = get_version(opts, "hl-composer")
     config_yaml = "{dir}/hl-composer/{release}.yaml".format(
                 dir=opts["core"]["dir_values"], release=opts["composer"]["name"]
             )
     if not upgrade:
-        extra_vars = helm_extra_vars(config_yaml=config_yaml)
+        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
         helm_install(
             opts["core"]["chart_repo"],
             "hl-composer",
@@ -134,7 +135,7 @@ def deploy_composer(opts, upgrade=False, verbose=False):
                 "rest.config.apiKey",
             ),
         )
-        extra_vars = helm_extra_vars(config_yaml=config_yaml, preserve=preserve)
+        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml, preserve=preserve)
         helm_upgrade(
             opts["core"]["chart_repo"],
             "hl-composer",

--- a/nephos/fabric/ca.py
+++ b/nephos/fabric/ca.py
@@ -18,7 +18,13 @@ from time import sleep
 from kubernetes.client.rest import ApiException
 from nephos.fabric.settings import get_namespace, get_version
 from nephos.fabric.utils import get_pod
-from nephos.helpers.helm import HelmPreserve, helm_check, helm_extra_vars, helm_install, helm_upgrade
+from nephos.helpers.helm import (
+    HelmPreserve,
+    helm_check,
+    helm_extra_vars,
+    helm_install,
+    helm_upgrade,
+)
 from nephos.helpers.k8s import ingress_read, secret_read
 from nephos.helpers.misc import execute_until_success
 
@@ -65,11 +71,11 @@ def ca_chart(opts, release, upgrade=False, verbose=False):
     # Fabric CA
     version = get_version(opts, "hlf-ca")
     env_vars = [("externalDatabase.password", psql_password)]
-    config_yaml = "{dir}/hlf-ca/{name}.yaml".format(
-        dir=values_dir, name=release
-    )
+    config_yaml = "{dir}/hlf-ca/{name}.yaml".format(dir=values_dir, name=release)
     if not upgrade:
-        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml, env_vars=env_vars)
+        extra_vars = helm_extra_vars(
+            version=version, config_yaml=config_yaml, env_vars=env_vars
+        )
         helm_install(
             repository,
             "hlf-ca",
@@ -81,19 +87,26 @@ def ca_chart(opts, release, upgrade=False, verbose=False):
     else:
         preserve = (
             HelmPreserve(
-                ca_namespace, "{}-hlf-ca--ca".format(release), "CA_ADMIN", "adminUsername"
+                ca_namespace,
+                "{}-hlf-ca--ca".format(release),
+                "CA_ADMIN",
+                "adminUsername",
             ),
             HelmPreserve(
-                ca_namespace, "{}-hlf-ca--ca".format(release), "CA_PASSWORD", "adminPassword"
+                ca_namespace,
+                "{}-hlf-ca--ca".format(release),
+                "CA_PASSWORD",
+                "adminPassword",
             ),
         )
-        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml, env_vars=env_vars, preserve=preserve)
+        extra_vars = helm_extra_vars(
+            version=version,
+            config_yaml=config_yaml,
+            env_vars=env_vars,
+            preserve=preserve,
+        )
         helm_upgrade(
-            repository,
-            "hlf-ca",
-            release,
-            extra_vars=extra_vars,
-            verbose=verbose,
+            repository, "hlf-ca", release, extra_vars=extra_vars, verbose=verbose
         )
     helm_check("hlf-ca", release, ca_namespace)
 

--- a/nephos/fabric/ca.py
+++ b/nephos/fabric/ca.py
@@ -73,9 +73,11 @@ def ca_chart(opts, release, upgrade=False, verbose=False):
         # TODO: Remove this try/catch once all CAs are updated
         try:
             preserve = (
-                HelmPreserve("{}-hlf-ca".format(release), "CA_ADMIN", "adminUsername"),
                 HelmPreserve(
-                    "{}-hlf-ca".format(release), "CA_PASSWORD", "adminPassword"
+                    ca_namespace, "{}-hlf-ca".format(release), "CA_ADMIN", "adminUsername"
+                ),
+                HelmPreserve(
+                    ca_namespace, "{}-hlf-ca".format(release), "CA_PASSWORD", "adminPassword"
                 ),
             )
             helm_upgrade(
@@ -93,10 +95,10 @@ def ca_chart(opts, release, upgrade=False, verbose=False):
         except:
             preserve = (
                 HelmPreserve(
-                    "{}-hlf-ca--ca".format(release), "CA_ADMIN", "adminUsername"
+                    ca_namespace, "{}-hlf-ca--ca".format(release), "CA_ADMIN", "adminUsername"
                 ),
                 HelmPreserve(
-                    "{}-hlf-ca--ca".format(release), "CA_PASSWORD", "adminPassword"
+                    ca_namespace, "{}-hlf-ca--ca".format(release), "CA_PASSWORD", "adminPassword"
                 ),
             )
             helm_upgrade(

--- a/nephos/fabric/ca.py
+++ b/nephos/fabric/ca.py
@@ -18,7 +18,7 @@ from time import sleep
 from kubernetes.client.rest import ApiException
 from nephos.fabric.settings import get_namespace
 from nephos.fabric.utils import get_pod
-from nephos.helpers.helm import HelmPreserve, helm_install, helm_upgrade
+from nephos.helpers.helm import HelmPreserve, helm_check, helm_install, helm_upgrade
 from nephos.helpers.k8s import ingress_read, secret_read
 from nephos.helpers.misc import execute_until_success
 
@@ -49,6 +49,7 @@ def ca_chart(opts, release, upgrade=False, verbose=False):
         ),
         verbose=verbose,
     )
+    helm_check("postgresql", "{}-pg".format(release), ca_namespace)
     psql_secret = secret_read(
         "{}-pg-postgresql".format(release), ca_namespace, verbose=verbose
     )
@@ -110,6 +111,7 @@ def ca_chart(opts, release, upgrade=False, verbose=False):
                 preserve=preserve,
                 verbose=verbose,
             )
+    helm_check("hlf-ca", release, ca_namespace)
 
 
 def ca_enroll(pod_exec):

--- a/nephos/fabric/ord.py
+++ b/nephos/fabric/ord.py
@@ -81,8 +81,8 @@ def setup_ord(opts, upgrade=False, verbose=False):
         # Kafka upgrade is risky, so we disallow it by default
         version = get_version(opts, "kafka")
         config_yaml = "{dir}/kafka/kafka-hlf.yaml".format(
-                dir=opts["core"]["dir_values"]
-            )
+            dir=opts["core"]["dir_values"]
+        )
         extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
         helm_install(
             "incubator",
@@ -92,14 +92,19 @@ def setup_ord(opts, upgrade=False, verbose=False):
             extra_vars=extra_vars,
             verbose=verbose,
         )
-        helm_check("kafka", "kafka-hlf", ord_namespace, pod_num=opts["orderers"]["kafka"]["pod_num"])
+        helm_check(
+            "kafka",
+            "kafka-hlf",
+            ord_namespace,
+            pod_num=opts["orderers"]["kafka"]["pod_num"],
+        )
 
     for release in opts["orderers"]["names"]:
         # HL-Ord
         version = get_version(opts, "hlf-ord")
         config_yaml = "{dir}/hlf-ord/{name}.yaml".format(
-                dir=opts["core"]["dir_values"], name=release
-            )
+            dir=opts["core"]["dir_values"], name=release
+        )
         extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
         if not upgrade:
             helm_install(

--- a/nephos/fabric/ord.py
+++ b/nephos/fabric/ord.py
@@ -16,7 +16,7 @@ from time import sleep
 
 from nephos.fabric.utils import get_pod
 from nephos.fabric.settings import get_namespace
-from nephos.helpers.helm import helm_install, helm_upgrade
+from nephos.helpers.helm import helm_check, helm_install, helm_upgrade
 from nephos.helpers.misc import execute
 
 
@@ -87,9 +87,9 @@ def setup_ord(opts, upgrade=False, verbose=False):
             config_yaml="{dir}/kafka/kafka-hlf.yaml".format(
                 dir=opts["core"]["dir_values"]
             ),
-            pod_num=opts["orderers"]["kafka"]["pod_num"],
             verbose=verbose,
         )
+        helm_check("kafka", "kafka-hlf", ord_namespace, pod_num=opts["orderers"]["kafka"]["pod_num"])
 
     for release in opts["orderers"]["names"]:
         # HL-Ord
@@ -115,5 +115,6 @@ def setup_ord(opts, upgrade=False, verbose=False):
                 ),
                 verbose=verbose,
             )
+        helm_check("hlf-ord", release, ord_namespace)
         # Check that Orderer is running
         check_ord(ord_namespace, release, verbose=verbose)

--- a/nephos/fabric/ord.py
+++ b/nephos/fabric/ord.py
@@ -15,7 +15,7 @@
 from time import sleep
 
 from nephos.fabric.utils import get_pod
-from nephos.fabric.settings import get_namespace
+from nephos.fabric.settings import get_namespace, get_version
 from nephos.helpers.helm import helm_check, helm_extra_vars, helm_install, helm_upgrade
 from nephos.helpers.misc import execute
 
@@ -79,10 +79,11 @@ def setup_ord(opts, upgrade=False, verbose=False):
     # Kafka
     if "kafka" in opts["orderers"]:
         # Kafka upgrade is risky, so we disallow it by default
-        extra_vars = helm_extra_vars(
-            config_yaml="{dir}/kafka/kafka-hlf.yaml".format(
+        version = get_version(opts, "kafka")
+        config_yaml = "{dir}/kafka/kafka-hlf.yaml".format(
                 dir=opts["core"]["dir_values"]
-            ))
+            )
+        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
         helm_install(
             "incubator",
             "kafka",
@@ -95,10 +96,11 @@ def setup_ord(opts, upgrade=False, verbose=False):
 
     for release in opts["orderers"]["names"]:
         # HL-Ord
-        extra_vars = helm_extra_vars(
-            config_yaml="{dir}/hlf-ord/{name}.yaml".format(
+        version = get_version(opts, "hlf-ord")
+        config_yaml = "{dir}/hlf-ord/{name}.yaml".format(
                 dir=opts["core"]["dir_values"], name=release
-            ))
+            )
+        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
         if not upgrade:
             helm_install(
                 opts["core"]["chart_repo"],

--- a/nephos/fabric/peer.py
+++ b/nephos/fabric/peer.py
@@ -18,7 +18,7 @@ from time import sleep
 from nephos.fabric.ord import check_ord_tls
 from nephos.fabric.settings import get_namespace
 from nephos.fabric.utils import get_pod
-from nephos.helpers.helm import HelmPreserve, helm_install, helm_upgrade
+from nephos.helpers.helm import HelmPreserve, helm_check, helm_install, helm_upgrade
 
 
 def check_peer(namespace, release, verbose=False):
@@ -93,6 +93,7 @@ def setup_peer(opts, upgrade=False, verbose=False):
                 preserve=preserve,
                 verbose=verbose,
             )
+        helm_check("hlf-couchdb", "cdb-{}".format(release), peer_namespace)
 
         # Deploy the HL-Peer charts
         if not upgrade:
@@ -117,7 +118,8 @@ def setup_peer(opts, upgrade=False, verbose=False):
                 ),
                 verbose=verbose,
             )
-
+        helm_check("hlf-peer", release, peer_namespace)
+        # Check that peer is running
         check_peer(peer_namespace, release, verbose=verbose)
 
 

--- a/nephos/fabric/peer.py
+++ b/nephos/fabric/peer.py
@@ -91,7 +91,7 @@ def setup_peer(opts, upgrade=False, verbose=False):
                 opts["core"]["chart_repo"],
                 "hlf-couchdb",
                 "cdb-{}".format(release),
-                extra_vars,
+                extra_vars=extra_vars,
                 verbose=verbose,
             )
         helm_check("hlf-couchdb", "cdb-{}".format(release), peer_namespace)

--- a/nephos/fabric/peer.py
+++ b/nephos/fabric/peer.py
@@ -18,7 +18,13 @@ from time import sleep
 from nephos.fabric.ord import check_ord_tls
 from nephos.fabric.settings import get_namespace, get_version
 from nephos.fabric.utils import get_pod
-from nephos.helpers.helm import HelmPreserve, helm_check, helm_extra_vars, helm_install, helm_upgrade
+from nephos.helpers.helm import (
+    HelmPreserve,
+    helm_check,
+    helm_extra_vars,
+    helm_install,
+    helm_upgrade,
+)
 
 
 def check_peer(namespace, release, verbose=False):
@@ -87,7 +93,9 @@ def setup_peer(opts, upgrade=False, verbose=False):
                     "couchdbPassword",
                 ),
             )
-            extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml, preserve=preserve)
+            extra_vars = helm_extra_vars(
+                version=version, config_yaml=config_yaml, preserve=preserve
+            )
             helm_upgrade(
                 opts["core"]["chart_repo"],
                 "hlf-couchdb",

--- a/nephos/fabric/peer.py
+++ b/nephos/fabric/peer.py
@@ -16,7 +16,7 @@ import random
 from time import sleep
 
 from nephos.fabric.ord import check_ord_tls
-from nephos.fabric.settings import get_namespace
+from nephos.fabric.settings import get_namespace, get_version
 from nephos.fabric.utils import get_pod
 from nephos.helpers.helm import HelmPreserve, helm_check, helm_extra_vars, helm_install, helm_upgrade
 
@@ -58,11 +58,12 @@ def setup_peer(opts, upgrade=False, verbose=False):
     peer_namespace = get_namespace(opts, opts["peers"]["msp"])
     for release in opts["peers"]["names"]:
         # Deploy the CouchDB instances
+        version = get_version(opts, "hlf-couchdb")
         config_yaml = "{dir}/hlf-couchdb/cdb-{name}.yaml".format(
             dir=opts["core"]["dir_values"], name=release
         )
         if not upgrade:
-            extra_vars = helm_extra_vars(config_yaml=config_yaml)
+            extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
             helm_install(
                 opts["core"]["chart_repo"],
                 "hlf-couchdb",
@@ -86,7 +87,7 @@ def setup_peer(opts, upgrade=False, verbose=False):
                     "couchdbPassword",
                 ),
             )
-            extra_vars = helm_extra_vars(config_yaml=config_yaml, preserve=preserve)
+            extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml, preserve=preserve)
             helm_upgrade(
                 opts["core"]["chart_repo"],
                 "hlf-couchdb",
@@ -97,9 +98,11 @@ def setup_peer(opts, upgrade=False, verbose=False):
         helm_check("hlf-couchdb", "cdb-{}".format(release), peer_namespace)
 
         # Deploy the HL-Peer charts
-        extra_vars = helm_extra_vars(config_yaml="{dir}/hlf-peer/{name}.yaml".format(
+        version = get_version(opts, "hlf-peer")
+        config_yaml = "{dir}/hlf-peer/{name}.yaml".format(
             dir=opts["core"]["dir_values"], name=release
-        ))
+        )
+        extra_vars = helm_extra_vars(version=version, config_yaml=config_yaml)
         if not upgrade:
             helm_install(
                 opts["core"]["chart_repo"],

--- a/nephos/fabric/peer.py
+++ b/nephos/fabric/peer.py
@@ -72,11 +72,13 @@ def setup_peer(opts, upgrade=False, verbose=False):
         else:
             preserve = (
                 HelmPreserve(
+                    peer_namespace,
                     "cdb-{}-hlf-couchdb".format(release),
                     "COUCHDB_USERNAME",
                     "couchdbUsername",
                 ),
                 HelmPreserve(
+                    peer_namespace,
                     "cdb-{}-hlf-couchdb".format(release),
                     "COUCHDB_PASSWORD",
                     "couchdbPassword",

--- a/nephos/fabric/settings.py
+++ b/nephos/fabric/settings.py
@@ -78,6 +78,22 @@ def get_namespace(opts, msp=None, ca=None):
     return opts["core"]["namespace"]
 
 
+def get_version(opts, app):
+    """Get version of a specific app
+
+    Args:
+        opts (dict): Nephos options dict.
+        app (str): Helm application name.
+
+    Returns:
+        str: Desired version of Helm app, if specified. Defaults to None.
+    """
+    if app in opts["versions"]:
+        return opts["versions"][app]
+    else:
+        return None
+
+
 def load_config(settings_file):
     """Load configuration from Nephos options/settings YAML file.
 

--- a/nephos/fabric/settings.py
+++ b/nephos/fabric/settings.py
@@ -88,7 +88,7 @@ def get_version(opts, app):
     Returns:
         str: Desired version of Helm app, if specified. Defaults to None.
     """
-    if app in opts["versions"]:
+    if "versions" in opts and app in opts["versions"]:
         return opts["versions"][app]
     else:
         return None

--- a/nephos/helpers/helm.py
+++ b/nephos/helpers/helm.py
@@ -133,7 +133,6 @@ def helm_preserve(namespace, preserve, verbose=False):
 
 # TODO: Too many parameters - SQ Code Smell
 # TODO: Cleanest way of fixing parameter issues is via a Helm class
-# TODO: We should ideally auto-detect number of pods
 def helm_install(
     repo,
     app,
@@ -143,7 +142,6 @@ def helm_install(
     env_vars=None,
     version=None,
     verbose=False,
-    pod_num=1,
 ):
     """Install Helm chart.
 
@@ -156,7 +154,6 @@ def helm_install(
         env_vars (tuple): List of env vars we want to set.
         version (str): Which Chart version do we wish to install?
         verbose (bool): Verbosity. False by default.
-        pod_num (int): Number of pods we wish to have.
     """
     ls_res, _ = execute("helm status {release}".format(release=release))
 
@@ -174,11 +171,9 @@ def helm_install(
         command += env_vars_string
         # Execute
         execute(command, verbose=verbose)
-    helm_check(app, release, namespace, pod_num)
 
 
 # TODO: Too many parameters - SQ Code Smell
-# TODO: We should ideally auto-detect number of pods
 def helm_upgrade(
     repo,
     app,
@@ -189,7 +184,6 @@ def helm_upgrade(
     preserve=None,
     version=None,
     verbose=False,
-    pod_num=1,
 ):
     """Upgrade Helm chart.
 
@@ -203,7 +197,6 @@ def helm_upgrade(
         preserve (tuple): Set of secrets we wish to get data from to assign to the Helm Chart.
         version (str): Which Chart version do we wish to install?
         verbose (bool): Verbosity. False by default.
-        pod_num (int): Number of pods we wish to have.
     """
     ls_res, _ = execute("helm status {release}".format(release=release))
 
@@ -224,4 +217,3 @@ def helm_upgrade(
         execute(command, verbose=verbose)
     else:
         raise Exception("Cannot update a Helm release that is not running")
-    helm_check(app, release, namespace, pod_num)

--- a/nephos/helpers/helm.py
+++ b/nephos/helpers/helm.py
@@ -155,17 +155,12 @@ def helm_extra_vars(version=None, config_yaml=None, env_vars=None, preserve=None
     return extra_vars_string
 
 
-# TODO: Too many parameters - SQ Code Smell
-# TODO: Cleanest way of fixing parameter issues is via a Helm class
 def helm_install(
     repo,
     app,
     release,
     namespace,
-    # extra_vars=None,
-    config_yaml=None,
-    env_vars=None,
-    version=None,
+    extra_vars="",
     verbose=False,
 ):
     """Install Helm chart.
@@ -175,40 +170,25 @@ def helm_install(
         app (str): Helm application name.
         release (str): Release name on K8S.
         namespace (str): Namespace where to deploy Helm Chart.
-        # extra_vars (str): Extra variables for Helm including version, values files and environmental variables.
-        config_yaml (str): Values file to override defaults.
-        env_vars (Iterable): List of env vars we want to set.
-        version (str): Which Chart version do we wish to install?
+        extra_vars (str): Extra variables for Helm including version, values files and environmental variables.
         verbose (bool): Verbosity. False by default.
     """
     ls_res, _ = execute("helm status {release}".format(release=release))
-
-    # Get Helm Env-Vars
-    env_vars_string = helm_env_vars(env_vars)
 
     if not ls_res:
         command = "helm install {repo}/{app} -n {name} --namespace {ns}".format(
             app=app, name=release, ns=namespace, repo=repo
         )
-        if version:
-            command += " --version {}".format(version)
-        if config_yaml:
-            command += " -f {}".format(config_yaml)
-        command += env_vars_string
+        command += extra_vars
         # Execute
         execute(command, verbose=verbose)
 
 
-# TODO: Too many parameters - SQ Code Smell
 def helm_upgrade(
     repo,
     app,
     release,
-    # extra_vars=None,
-    config_yaml=None,
-    env_vars=None,
-    preserve=None,
-    version=None,
+    extra_vars="",
     verbose=False,
 ):
     """Upgrade Helm chart.
@@ -217,28 +197,17 @@ def helm_upgrade(
         repo (str): Repository or folder from which to install Helm chart.
         app (str): Helm application name.
         release (str): Release name on K8S.
-        # extra_vars (str): Extra variables for Helm including version, values files and environmental variables.
-        config_yaml (str): Values file to override defaults.
-        env_vars (Iterable): Environmental variables we wish to store in Helm.
-        preserve (Iterable): Set of secrets we wish to get data from to assign to the Helm Chart.
-        version (str): Which Chart version do we wish to install?
+        extra_vars (str): Extra variables for Helm including version, values files and environmental variables.
         verbose (bool): Verbosity. False by default.
     """
     ls_res, _ = execute("helm status {release}".format(release=release))
-
-    # Get Helm Env-Vars
-    env_vars_string = helm_env_vars(env_vars)
-    env_vars_string += helm_preserve(preserve, verbose=verbose)
 
     if ls_res:
         command = "helm upgrade {name} {repo}/{app}".format(
             app=app, name=release, repo=repo
         )
-        if version:
-            command += " --version {}".format(version)
-        if config_yaml:
-            command += " -f {}".format(config_yaml)
-        command += env_vars_string
+
+        command += extra_vars or ""
         # Execute
         execute(command, verbose=verbose)
     else:

--- a/nephos/helpers/helm.py
+++ b/nephos/helpers/helm.py
@@ -141,6 +141,7 @@ def helm_install(
     namespace,
     config_yaml=None,
     env_vars=None,
+    version=None,
     verbose=False,
     pod_num=1,
 ):
@@ -151,8 +152,9 @@ def helm_install(
         app (str): Helm application name.
         release (str): Release name on K8S.
         namespace (str): Namespace where to deploy Helm Chart.
-        config_yaml (str): Values file to ovverride defaults.
+        config_yaml (str): Values file to override defaults.
         env_vars (tuple): List of env vars we want to set.
+        version (str): Which Chart version do we wish to install?
         verbose (bool): Verbosity. False by default.
         pod_num (int): Number of pods we wish to have.
     """
@@ -165,6 +167,8 @@ def helm_install(
         command = "helm install {repo}/{app} -n {name} --namespace {ns}".format(
             app=app, name=release, ns=namespace, repo=repo
         )
+        if version:
+            command += " --version {}".format(version)
         if config_yaml:
             command += " -f {}".format(config_yaml)
         command += env_vars_string
@@ -183,6 +187,7 @@ def helm_upgrade(
     config_yaml=None,
     env_vars=None,
     preserve=None,
+    version=None,
     verbose=False,
     pod_num=1,
 ):
@@ -193,9 +198,10 @@ def helm_upgrade(
         app (str): Helm application name.
         release (str): Release name on K8S.
         namespace (str): Namespace where to deploy Helm Chart.
-        config_yaml (str): Values file to ovverride defaults.
+        config_yaml (str): Values file to override defaults.
         env_vars (tuple): Environmental variables we wish to store in Helm.
         preserve (tuple): Set of secrets we wish to get data from to assign to the Helm Chart.
+        version (str): Which Chart version do we wish to install?
         verbose (bool): Verbosity. False by default.
         pod_num (int): Number of pods we wish to have.
     """
@@ -209,6 +215,8 @@ def helm_upgrade(
         command = "helm upgrade {name} {repo}/{app}".format(
             app=app, name=release, repo=repo
         )
+        if version:
+            command += " --version {}".format(version)
         if config_yaml:
             command += " -f {}".format(config_yaml)
         command += env_vars_string

--- a/nephos/helpers/helm.py
+++ b/nephos/helpers/helm.py
@@ -11,7 +11,9 @@ from nephos.helpers.misc import execute
 
 TERM = Terminal()
 
-HelmPreserve = namedtuple("HelmPreserve", ("secret_namespace", "secret_name", "data_item", "values_path"))
+HelmPreserve = namedtuple(
+    "HelmPreserve", ("secret_namespace", "secret_name", "data_item", "values_path")
+)
 # noinspection PyArgumentList
 HelmSet = namedtuple("HelmSet", ("key", "value", "set_string"), defaults=(False,))
 
@@ -28,9 +30,7 @@ def helm_check(app, release, namespace, pod_num=None):
         namespace (str): Namespace where Helm deployment is located.
         pod_num (int): Number of pods expected to exist in the release.
     """
-    identifier = '-l "app={app},release={name}"'.format(
-        app=app, name=release
-    )
+    identifier = '-l "app={app},release={name}"'.format(app=app, name=release)
     pod_check(namespace, identifier, pod_num=pod_num)
 
 
@@ -109,7 +109,9 @@ def helm_preserve(preserve, verbose=False):
             item = HelmPreserve(*item)
         elif not isinstance(item, HelmPreserve):
             raise TypeError("Items in preserve array must be HelmPerserve named tuples")
-        secret_data = secret_read(item.secret_name, item.secret_namespace, verbose=verbose)
+        secret_data = secret_read(
+            item.secret_name, item.secret_namespace, verbose=verbose
+        )
         env_vars.append(HelmSet(item.values_path, secret_data[item.data_item]))
     # Environmental variables
     # TODO: This may well be its own subfunction
@@ -124,7 +126,9 @@ def helm_preserve(preserve, verbose=False):
     return env_vars_string
 
 
-def helm_extra_vars(version=None, config_yaml=None, env_vars=None, preserve=None, verbose=False):
+def helm_extra_vars(
+    version=None, config_yaml=None, env_vars=None, preserve=None, verbose=False
+):
     """Centralise obtaining extra variables for our helm_install and/or helm_upgrade
 
     Args:
@@ -155,14 +159,7 @@ def helm_extra_vars(version=None, config_yaml=None, env_vars=None, preserve=None
     return extra_vars_string
 
 
-def helm_install(
-    repo,
-    app,
-    release,
-    namespace,
-    extra_vars="",
-    verbose=False,
-):
+def helm_install(repo, app, release, namespace, extra_vars="", verbose=False):
     """Install Helm chart.
 
     Args:
@@ -184,13 +181,7 @@ def helm_install(
         execute(command, verbose=verbose)
 
 
-def helm_upgrade(
-    repo,
-    app,
-    release,
-    extra_vars="",
-    verbose=False,
-):
+def helm_upgrade(repo, app, release, extra_vars="", verbose=False):
     """Upgrade Helm chart.
 
     Args:

--- a/nephos/helpers/misc.py
+++ b/nephos/helpers/misc.py
@@ -82,7 +82,7 @@ def input_files(keys, clean_key=False):
     """Read a set of filenames and return data from them.
 
     Args:
-        keys (tuple): Tuple of keys
+        keys (Iterable): Tuple of keys
         clean_key (bool): Do we clean the key to replace non-alphanumeric symbols with an underscore? False by default.
 
     Returns:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ URL = "https://github.com/aidtechnology/nephos"
 EMAIL = "sasha@aid.technology"
 AUTHOR = "Alejandro (Sasha) Vicente Grabovetsky"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.2.11"
+VERSION = "0.3.0"
 
 # What packages are required for this module to be executed?
 REQUIRED = ["blessings", "click", "kubernetes", "pygments"]

--- a/tests/composer/test_install.py
+++ b/tests/composer/test_install.py
@@ -112,10 +112,12 @@ class TestDeployComposer:
     @patch("nephos.composer.install.secret_from_file")
     @patch("nephos.composer.install.helm_upgrade")
     @patch("nephos.composer.install.helm_install")
+    @patch("nephos.composer.install.helm_check")
     @patch("nephos.composer.install.composer_connection")
     def test_deploy_composer(
         self,
         mock_composer_connection,
+        mock_helm_check,
         mock_helm_install,
         mock_helm_upgrade,
         mock_secret_from_file,
@@ -130,19 +132,22 @@ class TestDeployComposer:
             "hl-composer",
             "hlc",
             "peer-namespace",
-            pod_num=3,
             config_yaml="./a_dir/hl-composer/hlc.yaml",
             verbose=False,
         )
         mock_helm_upgrade.assert_not_called()
+        mock_helm_check.assert_called_once_with(
+            "hl-composer", "hlc", "peer-namespace", pod_num=3)
 
     @patch("nephos.composer.install.secret_from_file")
     @patch("nephos.composer.install.helm_upgrade")
     @patch("nephos.composer.install.helm_install")
+    @patch("nephos.composer.install.helm_check")
     @patch("nephos.composer.install.composer_connection")
     def test_deploy_composer_upgrade(
         self,
         mock_composer_connection,
+        mock_helm_check,
         mock_helm_install,
         mock_helm_upgrade,
         mock_secret_from_file,
@@ -158,7 +163,6 @@ class TestDeployComposer:
             "hl-composer",
             "hlc",
             "peer-namespace",
-            pod_num=3,
             config_yaml="./a_dir/hl-composer/hlc.yaml",
             preserve=(
                 HelmPreserve(
@@ -167,6 +171,8 @@ class TestDeployComposer:
             ),
             verbose=True,
         )
+        mock_helm_check.assert_called_once_with(
+            "hl-composer", "hlc", "peer-namespace", pod_num=3)
 
 
 class TestSetupAdmin:

--- a/tests/composer/test_install.py
+++ b/tests/composer/test_install.py
@@ -124,17 +124,21 @@ class TestDeployComposer:
         mock_helm_upgrade,
         mock_secret_from_file,
     ):
+        mock_helm_extra_vars.side_effect = ["extra-vars"]
         deploy_composer(self.OPTS)
         mock_secret_from_file.assert_called_once_with(
             secret="bna-secret", namespace="peer-namespace", verbose=False
         )
         mock_composer_connection.assert_called_once_with(self.OPTS, verbose=False)
+        mock_helm_extra_vars.assert_called_once_with(
+            config_yaml="./a_dir/hl-composer/hlc.yaml"
+        )
         mock_helm_install.assert_called_once_with(
             "a-repo",
             "hl-composer",
             "hlc",
             "peer-namespace",
-            config_yaml="./a_dir/hl-composer/hlc.yaml",
+            extra_vars="extra-vars",
             verbose=False,
         )
         mock_helm_upgrade.assert_not_called()
@@ -156,23 +160,24 @@ class TestDeployComposer:
         mock_helm_upgrade,
         mock_secret_from_file,
     ):
+        mock_helm_extra_vars.side_effect = ["extra-vars"]
         deploy_composer(self.OPTS, upgrade=True, verbose=True)
         mock_secret_from_file.assert_called_once_with(
             secret="bna-secret", namespace="peer-namespace", verbose=True
         )
         mock_composer_connection.assert_called_once_with(self.OPTS, verbose=True)
         mock_helm_install.assert_not_called()
+        mock_helm_extra_vars.assert_called_once_with(
+            config_yaml="./a_dir/hl-composer/hlc.yaml",
+            preserve=(HelmPreserve(
+                    "peer-namespace", "hlc-hl-composer-rest", "COMPOSER_APIKEY", "rest.config.apiKey"
+                ),)
+        )
         mock_helm_upgrade.assert_called_once_with(
             "a-repo",
             "hl-composer",
             "hlc",
-            "peer-namespace",
-            config_yaml="./a_dir/hl-composer/hlc.yaml",
-            preserve=(
-                HelmPreserve(
-                    "peer-namespace", "hlc-hl-composer-rest", "COMPOSER_APIKEY", "rest.config.apiKey"
-                ),
-            ),
+            extra_vars="extra-vars",
             verbose=True,
         )
         mock_helm_check.assert_called_once_with(

--- a/tests/composer/test_install.py
+++ b/tests/composer/test_install.py
@@ -133,9 +133,7 @@ class TestDeployComposer:
             secret="bna-secret", namespace="peer-namespace", verbose=False
         )
         mock_composer_connection.assert_called_once_with(self.OPTS, verbose=False)
-        mock_get_version.assert_has_calls([
-            call(self.OPTS, "hl-composer")
-        ])
+        mock_get_version.assert_has_calls([call(self.OPTS, "hl-composer")])
         mock_helm_extra_vars.assert_called_once_with(
             version="hlc-version", config_yaml="./a_dir/hl-composer/hlc.yaml"
         )
@@ -149,7 +147,8 @@ class TestDeployComposer:
         )
         mock_helm_upgrade.assert_not_called()
         mock_helm_check.assert_called_once_with(
-            "hl-composer", "hlc", "peer-namespace", pod_num=3)
+            "hl-composer", "hlc", "peer-namespace", pod_num=3
+        )
 
     @patch("nephos.composer.install.secret_from_file")
     @patch("nephos.composer.install.helm_upgrade")
@@ -175,26 +174,26 @@ class TestDeployComposer:
             secret="bna-secret", namespace="peer-namespace", verbose=True
         )
         mock_composer_connection.assert_called_once_with(self.OPTS, verbose=True)
-        mock_get_version.assert_has_calls([
-            call(self.OPTS, "hl-composer")
-        ])
+        mock_get_version.assert_has_calls([call(self.OPTS, "hl-composer")])
         mock_helm_extra_vars.assert_called_once_with(
             version="hlc-version",
             config_yaml="./a_dir/hl-composer/hlc.yaml",
-            preserve=(HelmPreserve(
-                    "peer-namespace", "hlc-hl-composer-rest", "COMPOSER_APIKEY", "rest.config.apiKey"
-                ),)
+            preserve=(
+                HelmPreserve(
+                    "peer-namespace",
+                    "hlc-hl-composer-rest",
+                    "COMPOSER_APIKEY",
+                    "rest.config.apiKey",
+                ),
+            ),
         )
         mock_helm_install.assert_not_called()
         mock_helm_upgrade.assert_called_once_with(
-            "a-repo",
-            "hl-composer",
-            "hlc",
-            extra_vars="extra-vars",
-            verbose=True,
+            "a-repo", "hl-composer", "hlc", extra_vars="extra-vars", verbose=True
         )
         mock_helm_check.assert_called_once_with(
-            "hl-composer", "hlc", "peer-namespace", pod_num=3)
+            "hl-composer", "hlc", "peer-namespace", pod_num=3
+        )
 
 
 class TestSetupAdmin:

--- a/tests/composer/test_install.py
+++ b/tests/composer/test_install.py
@@ -166,7 +166,7 @@ class TestDeployComposer:
             config_yaml="./a_dir/hl-composer/hlc.yaml",
             preserve=(
                 HelmPreserve(
-                    "hlc-hl-composer-rest", "COMPOSER_APIKEY", "rest.config.apiKey"
+                    "peer-namespace", "hlc-hl-composer-rest", "COMPOSER_APIKEY", "rest.config.apiKey"
                 ),
             ),
             verbose=True,

--- a/tests/composer/test_install.py
+++ b/tests/composer/test_install.py
@@ -112,12 +112,14 @@ class TestDeployComposer:
     @patch("nephos.composer.install.secret_from_file")
     @patch("nephos.composer.install.helm_upgrade")
     @patch("nephos.composer.install.helm_install")
+    @patch("nephos.composer.install.helm_extra_vars")
     @patch("nephos.composer.install.helm_check")
     @patch("nephos.composer.install.composer_connection")
     def test_deploy_composer(
         self,
         mock_composer_connection,
         mock_helm_check,
+        mock_helm_extra_vars,
         mock_helm_install,
         mock_helm_upgrade,
         mock_secret_from_file,
@@ -142,12 +144,14 @@ class TestDeployComposer:
     @patch("nephos.composer.install.secret_from_file")
     @patch("nephos.composer.install.helm_upgrade")
     @patch("nephos.composer.install.helm_install")
+    @patch("nephos.composer.install.helm_extra_vars")
     @patch("nephos.composer.install.helm_check")
     @patch("nephos.composer.install.composer_connection")
     def test_deploy_composer_upgrade(
         self,
         mock_composer_connection,
         mock_helm_check,
+        mock_helm_extra_vars,
         mock_helm_install,
         mock_helm_upgrade,
         mock_secret_from_file,

--- a/tests/fabric/test_ca.py
+++ b/tests/fabric/test_ca.py
@@ -18,29 +18,35 @@ class TestCaChart:
     @patch("nephos.fabric.ca.helm_extra_vars")
     @patch("nephos.fabric.ca.helm_check")
     @patch("nephos.fabric.ca.get_version")
-    def test_ca_chart(self, mock_get_version, mock_helm_check, mock_helm_extra_vars,
-                      mock_helm_install, mock_helm_upgrade, mock_secret_read):
+    def test_ca_chart(
+        self,
+        mock_get_version,
+        mock_helm_check,
+        mock_helm_extra_vars,
+        mock_helm_install,
+        mock_helm_upgrade,
+        mock_secret_read,
+    ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
-        mock_get_version.side_effect = [
-            "pg-version",
-            "ca-version"
-        ]
-        mock_helm_extra_vars.side_effect = [
-            "extra-vars-pg",
-            "extra-vars-ca"
-        ]
+        mock_get_version.side_effect = ["pg-version", "ca-version"]
+        mock_helm_extra_vars.side_effect = ["extra-vars-pg", "extra-vars-ca"]
         ca_chart(self.OPTS, "a-release", verbose=True)
-        mock_get_version.assert_has_calls([
-            call(self.OPTS, "postgresql"),
-            call(self.OPTS, "hlf-ca")
-        ])
-        mock_helm_extra_vars.assert_has_calls([
-            call(version="pg-version",
-                 config_yaml="./some_dir/postgres-ca/a-release-pg.yaml",),
-            call(version="ca-version",
-                 config_yaml="./some_dir/hlf-ca/a-release.yaml",
-                 env_vars=[("externalDatabase.password", "a_password")])
-        ])
+        mock_get_version.assert_has_calls(
+            [call(self.OPTS, "postgresql"), call(self.OPTS, "hlf-ca")]
+        )
+        mock_helm_extra_vars.assert_has_calls(
+            [
+                call(
+                    version="pg-version",
+                    config_yaml="./some_dir/postgres-ca/a-release-pg.yaml",
+                ),
+                call(
+                    version="ca-version",
+                    config_yaml="./some_dir/hlf-ca/a-release.yaml",
+                    env_vars=[("externalDatabase.password", "a_password")],
+                ),
+            ]
+        )
         mock_helm_install.assert_has_calls(
             [
                 call(
@@ -65,10 +71,12 @@ class TestCaChart:
         mock_secret_read.assert_called_once_with(
             "a-release-pg-postgresql", "ca-namespace", verbose=True
         )
-        mock_helm_check.assert_has_calls([
-            call("postgresql", "a-release-pg", "ca-namespace"),
-            call("hlf-ca", "a-release", "ca-namespace"),
-        ])
+        mock_helm_check.assert_has_calls(
+            [
+                call("postgresql", "a-release-pg", "ca-namespace"),
+                call("hlf-ca", "a-release", "ca-namespace"),
+            ]
+        )
 
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
@@ -77,43 +85,43 @@ class TestCaChart:
     @patch("nephos.fabric.ca.helm_check")
     @patch("nephos.fabric.ca.get_version")
     def test_ca_chart_upgrade(
-        self, mock_get_version, mock_helm_check, mock_helm_extra_vars,
-            mock_helm_install, mock_helm_upgrade, mock_secret_read
+        self,
+        mock_get_version,
+        mock_helm_check,
+        mock_helm_extra_vars,
+        mock_helm_install,
+        mock_helm_upgrade,
+        mock_secret_read,
     ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
-        mock_get_version.side_effect = [
-            "ca-version"
-        ]
-        mock_helm_extra_vars.side_effect = [
-            "extra-vars-ca"
-        ]
+        mock_get_version.side_effect = ["ca-version"]
+        mock_helm_extra_vars.side_effect = ["extra-vars-ca"]
         ca_chart(self.OPTS, "a-release", upgrade=True)
-        mock_get_version.assert_has_calls([
-            call(self.OPTS, "hlf-ca")
-        ])
+        mock_get_version.assert_has_calls([call(self.OPTS, "hlf-ca")])
         mock_helm_extra_vars.assert_called_once_with(
             version="ca-version",
             config_yaml="./some_dir/hlf-ca/a-release.yaml",
             env_vars=[("externalDatabase.password", "a_password")],
             preserve=(
-                HelmPreserve("ca-namespace", "a-release-hlf-ca--ca", "CA_ADMIN", "adminUsername"),
-                HelmPreserve("ca-namespace", "a-release-hlf-ca--ca", "CA_PASSWORD", "adminPassword"),
-            )
+                HelmPreserve(
+                    "ca-namespace", "a-release-hlf-ca--ca", "CA_ADMIN", "adminUsername"
+                ),
+                HelmPreserve(
+                    "ca-namespace",
+                    "a-release-hlf-ca--ca",
+                    "CA_PASSWORD",
+                    "adminPassword",
+                ),
+            ),
         )
         mock_helm_install.assert_not_called()
         mock_helm_upgrade.assert_called_once_with(
-            "a_repo",
-            "hlf-ca",
-            "a-release",
-            extra_vars="extra-vars-ca",
-            verbose=False,
+            "a_repo", "hlf-ca", "a-release", extra_vars="extra-vars-ca", verbose=False
         )
         mock_secret_read.assert_called_once_with(
             "a-release-pg-postgresql", "ca-namespace", verbose=False
         )
-        mock_helm_check.assert_has_calls([
-            call("hlf-ca", "a-release", "ca-namespace"),
-        ])
+        mock_helm_check.assert_has_calls([call("hlf-ca", "a-release", "ca-namespace")])
 
 
 class TestCaEnroll:

--- a/tests/fabric/test_ca.py
+++ b/tests/fabric/test_ca.py
@@ -58,8 +58,8 @@ class TestCaChart:
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         env_vars = [("externalDatabase.password", "a_password")]
         preserve = (
-            ("a-release-hlf-ca", "CA_ADMIN", "adminUsername"),
-            ("a-release-hlf-ca", "CA_PASSWORD", "adminPassword"),
+            ("ca-namespace", "a-release-hlf-ca", "CA_ADMIN", "adminUsername"),
+            ("ca-namespace", "a-release-hlf-ca", "CA_PASSWORD", "adminPassword"),
         )
         ca_chart(self.OPTS, "a-release", upgrade=True)
         mock_helm_install.assert_called_once_with(
@@ -100,12 +100,12 @@ class TestCaChart:
         env_vars = [("externalDatabase.password", "a_password")]
         preserves = [
             (
-                ("a-release-hlf-ca", "CA_ADMIN", "adminUsername"),
-                ("a-release-hlf-ca", "CA_PASSWORD", "adminPassword"),
+                ("ca-namespace", "a-release-hlf-ca", "CA_ADMIN", "adminUsername"),
+                ("ca-namespace", "a-release-hlf-ca", "CA_PASSWORD", "adminPassword"),
             ),
             (
-                ("a-release-hlf-ca--ca", "CA_ADMIN", "adminUsername"),
-                ("a-release-hlf-ca--ca", "CA_PASSWORD", "adminPassword"),
+                ("ca-namespace", "a-release-hlf-ca--ca", "CA_ADMIN", "adminUsername"),
+                ("ca-namespace", "a-release-hlf-ca--ca", "CA_PASSWORD", "adminPassword"),
             ),
         ]
         ca_chart(self.OPTS, "a-release", upgrade=True)

--- a/tests/fabric/test_ca.py
+++ b/tests/fabric/test_ca.py
@@ -13,8 +13,10 @@ class TestCaChart:
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
+    @patch("nephos.fabric.ca.helm_extra_vars")
     @patch("nephos.fabric.ca.helm_check")
-    def test_ca_chart(self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read):
+    def test_ca_chart(self, mock_helm_check, mock_helm_extra_vars,
+                      mock_helm_install, mock_helm_upgrade, mock_secret_read):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         env_vars = [("externalDatabase.password", "a_password")]
         ca_chart(self.OPTS, "a-release")
@@ -51,9 +53,11 @@ class TestCaChart:
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
+    @patch("nephos.fabric.ca.helm_extra_vars")
     @patch("nephos.fabric.ca.helm_check")
     def test_ca_chart_upgrade(
-        self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read
+        self, mock_helm_check, mock_helm_extra_vars,
+            mock_helm_install, mock_helm_upgrade, mock_secret_read
     ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         env_vars = [("externalDatabase.password", "a_password")]
@@ -91,9 +95,11 @@ class TestCaChart:
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
+    @patch("nephos.fabric.ca.helm_extra_vars")
     @patch("nephos.fabric.ca.helm_check")
     def test_ca_chart_upgrade_old(
-        self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read
+        self, mock_helm_check, mock_helm_extra_vars,
+            mock_helm_install, mock_helm_upgrade, mock_secret_read
     ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         mock_helm_upgrade.side_effect = [Exception, None]
@@ -152,9 +158,11 @@ class TestCaChart:
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
+    @patch("nephos.fabric.ca.helm_extra_vars")
     @patch("nephos.fabric.ca.helm_check")
     def test_ca_chart_verbose(
-        self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read
+        self, mock_helm_check, mock_helm_extra_vars,
+            mock_helm_install, mock_helm_upgrade, mock_secret_read
     ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         env_vars = [("externalDatabase.password", "a_password")]

--- a/tests/fabric/test_ca.py
+++ b/tests/fabric/test_ca.py
@@ -13,7 +13,8 @@ class TestCaChart:
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
-    def test_ca_chart(self, mock_helm_install, mock_helm_upgrade, mock_secret_read):
+    @patch("nephos.fabric.ca.helm_check")
+    def test_ca_chart(self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         env_vars = [("externalDatabase.password", "a_password")]
         ca_chart(self.OPTS, "a-release")
@@ -42,12 +43,17 @@ class TestCaChart:
         mock_secret_read.assert_called_once_with(
             "a-release-pg-postgresql", "ca-namespace", verbose=False
         )
+        mock_helm_check.assert_has_calls([
+            call("postgresql", "a-release-pg", "ca-namespace"),
+            call("hlf-ca", "a-release", "ca-namespace"),
+        ])
 
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
+    @patch("nephos.fabric.ca.helm_check")
     def test_ca_chart_upgrade(
-        self, mock_helm_install, mock_helm_upgrade, mock_secret_read
+        self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read
     ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         env_vars = [("externalDatabase.password", "a_password")]
@@ -77,12 +83,17 @@ class TestCaChart:
         mock_secret_read.assert_called_once_with(
             "a-release-pg-postgresql", "ca-namespace", verbose=False
         )
+        mock_helm_check.assert_has_calls([
+            call("postgresql", "a-release-pg", "ca-namespace"),
+            call("hlf-ca", "a-release", "ca-namespace"),
+        ])
 
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
+    @patch("nephos.fabric.ca.helm_check")
     def test_ca_chart_upgrade_old(
-        self, mock_helm_install, mock_helm_upgrade, mock_secret_read
+        self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read
     ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         mock_helm_upgrade.side_effect = [Exception, None]
@@ -133,12 +144,17 @@ class TestCaChart:
         mock_secret_read.assert_called_once_with(
             "a-release-pg-postgresql", "ca-namespace", verbose=False
         )
+        mock_helm_check.assert_has_calls([
+            call("postgresql", "a-release-pg", "ca-namespace"),
+            call("hlf-ca", "a-release", "ca-namespace"),
+        ])
 
     @patch("nephos.fabric.ca.secret_read")
     @patch("nephos.fabric.ca.helm_upgrade")
     @patch("nephos.fabric.ca.helm_install")
+    @patch("nephos.fabric.ca.helm_check")
     def test_ca_chart_verbose(
-        self, mock_helm_install, mock_helm_upgrade, mock_secret_read
+        self, mock_helm_check, mock_helm_install, mock_helm_upgrade, mock_secret_read
     ):
         mock_secret_read.side_effect = [{"postgresql-password": "a_password"}]
         env_vars = [("externalDatabase.password", "a_password")]
@@ -168,6 +184,10 @@ class TestCaChart:
         mock_secret_read.assert_called_once_with(
             "a-release-pg-postgresql", "ca-namespace", verbose=True
         )
+        mock_helm_check.assert_has_calls([
+            call("postgresql", "a-release-pg", "ca-namespace"),
+            call("hlf-ca", "a-release", "ca-namespace"),
+        ])
 
 
 class TestCaEnroll:

--- a/tests/fabric/test_ord.py
+++ b/tests/fabric/test_ord.py
@@ -65,9 +65,11 @@ class TestSetupOrd:
 
     @patch("nephos.fabric.ord.helm_upgrade")
     @patch("nephos.fabric.ord.helm_install")
+    @patch("nephos.fabric.ord.helm_extra_vars")
     @patch("nephos.fabric.ord.helm_check")
     @patch("nephos.fabric.ord.check_ord")
-    def test_ord(self, mock_check_ord, mock_helm_check, mock_helm_install, mock_helm_upgrade):
+    def test_ord(self, mock_check_ord, mock_helm_check,
+                 mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         OPTS["orderers"]["names"] = ["ord0", "ord1"]
         setup_ord(OPTS)
@@ -105,9 +107,11 @@ class TestSetupOrd:
 
     @patch("nephos.fabric.ord.helm_upgrade")
     @patch("nephos.fabric.ord.helm_install")
+    @patch("nephos.fabric.ord.helm_extra_vars")
     @patch("nephos.fabric.ord.helm_check")
     @patch("nephos.fabric.ord.check_ord")
-    def test_ord_kafka(self, mock_check_ord, mock_helm_check, mock_helm_install, mock_helm_upgrade):
+    def test_ord_kafka(self, mock_check_ord, mock_helm_check,
+                       mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         OPTS["orderers"]["kafka"] = {"pod_num": 42}
         setup_ord(OPTS, verbose=True)
@@ -140,9 +144,11 @@ class TestSetupOrd:
 
     @patch("nephos.fabric.ord.helm_upgrade")
     @patch("nephos.fabric.ord.helm_install")
+    @patch("nephos.fabric.ord.helm_extra_vars")
     @patch("nephos.fabric.ord.helm_check")
     @patch("nephos.fabric.ord.check_ord")
-    def test_ord_upgrade(self, mock_check_ord, mock_helm_check, mock_helm_install, mock_helm_upgrade):
+    def test_ord_upgrade(self, mock_check_ord, mock_helm_check,
+                         mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         setup_ord(self.OPTS, upgrade=True)
         mock_helm_install.assert_not_called()
         mock_helm_upgrade.assert_called_once_with(

--- a/tests/fabric/test_ord.py
+++ b/tests/fabric/test_ord.py
@@ -70,29 +70,29 @@ class TestSetupOrd:
     @patch("nephos.fabric.ord.helm_check")
     @patch("nephos.fabric.ord.get_version")
     @patch("nephos.fabric.ord.check_ord")
-    def test_ord(self, mock_check_ord, mock_get_version, mock_helm_check,
-                 mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
+    def test_ord(
+        self,
+        mock_check_ord,
+        mock_get_version,
+        mock_helm_check,
+        mock_helm_extra_vars,
+        mock_helm_install,
+        mock_helm_upgrade,
+    ):
         OPTS = deepcopy(self.OPTS)
         OPTS["orderers"]["names"] = ["ord0", "ord1"]
-        mock_get_version.side_effect = [
-            "ord-version",
-            "ord-version",
-        ]
-        mock_helm_extra_vars.side_effect = [
-            "extra-vars-ord0",
-            "extra-vars-ord1"
-        ]
+        mock_get_version.side_effect = ["ord-version", "ord-version"]
+        mock_helm_extra_vars.side_effect = ["extra-vars-ord0", "extra-vars-ord1"]
         setup_ord(OPTS)
-        mock_get_version.assert_has_calls([
-            call(OPTS, "hlf-ord"),
-            call(OPTS, "hlf-ord")
-        ])
-        mock_helm_extra_vars.assert_has_calls([
-            call(version="ord-version",
-                 config_yaml="./a_dir/hlf-ord/ord0.yaml"),
-            call(version="ord-version",
-                 config_yaml="./a_dir/hlf-ord/ord1.yaml")
-        ])
+        mock_get_version.assert_has_calls(
+            [call(OPTS, "hlf-ord"), call(OPTS, "hlf-ord")]
+        )
+        mock_helm_extra_vars.assert_has_calls(
+            [
+                call(version="ord-version", config_yaml="./a_dir/hlf-ord/ord0.yaml"),
+                call(version="ord-version", config_yaml="./a_dir/hlf-ord/ord1.yaml"),
+            ]
+        )
         mock_helm_install.assert_has_calls(
             [
                 call(
@@ -114,10 +114,12 @@ class TestSetupOrd:
             ]
         )
         mock_helm_upgrade.assert_not_called()
-        mock_helm_check.assert_has_calls([
-            call("hlf-ord", "ord0", "ord-namespace"),
-            call("hlf-ord", "ord1", "ord-namespace"),
-        ])
+        mock_helm_check.assert_has_calls(
+            [
+                call("hlf-ord", "ord0", "ord-namespace"),
+                call("hlf-ord", "ord1", "ord-namespace"),
+            ]
+        )
         mock_check_ord.assert_has_calls(
             [
                 call("ord-namespace", "ord0", verbose=False),
@@ -131,29 +133,29 @@ class TestSetupOrd:
     @patch("nephos.fabric.ord.helm_check")
     @patch("nephos.fabric.ord.get_version")
     @patch("nephos.fabric.ord.check_ord")
-    def test_ord_kafka(self, mock_check_ord, mock_get_version, mock_helm_check,
-                       mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
+    def test_ord_kafka(
+        self,
+        mock_check_ord,
+        mock_get_version,
+        mock_helm_check,
+        mock_helm_extra_vars,
+        mock_helm_install,
+        mock_helm_upgrade,
+    ):
         OPTS = deepcopy(self.OPTS)
         OPTS["orderers"]["kafka"] = {"pod_num": 42}
-        mock_get_version.side_effect = [
-            "kafka-version",
-            "ord-version",
-        ]
-        mock_helm_extra_vars.side_effect = [
-            "extra-vars-kafka",
-            "extra-vars-ord0",
-        ]
+        mock_get_version.side_effect = ["kafka-version", "ord-version"]
+        mock_helm_extra_vars.side_effect = ["extra-vars-kafka", "extra-vars-ord0"]
         setup_ord(OPTS, verbose=True)
-        mock_get_version.assert_has_calls([
-            call(OPTS, "kafka"),
-            call(OPTS, "hlf-ord")
-        ])
-        mock_helm_extra_vars.assert_has_calls([
-            call(version="kafka-version",
-                 config_yaml="./a_dir/kafka/kafka-hlf.yaml"),
-            call(version="ord-version",
-                 config_yaml="./a_dir/hlf-ord/ord0.yaml")
-        ])
+        mock_get_version.assert_has_calls([call(OPTS, "kafka"), call(OPTS, "hlf-ord")])
+        mock_helm_extra_vars.assert_has_calls(
+            [
+                call(
+                    version="kafka-version", config_yaml="./a_dir/kafka/kafka-hlf.yaml"
+                ),
+                call(version="ord-version", config_yaml="./a_dir/hlf-ord/ord0.yaml"),
+            ]
+        )
         mock_helm_install.assert_has_calls(
             [
                 call(
@@ -175,10 +177,12 @@ class TestSetupOrd:
             ]
         )
         mock_helm_upgrade.assert_not_called()
-        mock_helm_check.assert_has_calls([
-            call("kafka", "kafka-hlf", "ord-namespace", pod_num=42),
-            call("hlf-ord", "ord0", "ord-namespace"),
-        ])
+        mock_helm_check.assert_has_calls(
+            [
+                call("kafka", "kafka-hlf", "ord-namespace", pod_num=42),
+                call("hlf-ord", "ord0", "ord-namespace"),
+            ]
+        )
         mock_check_ord.assert_called_once_with("ord-namespace", "ord0", verbose=True)
 
     @patch("nephos.fabric.ord.helm_upgrade")
@@ -187,31 +191,25 @@ class TestSetupOrd:
     @patch("nephos.fabric.ord.helm_check")
     @patch("nephos.fabric.ord.get_version")
     @patch("nephos.fabric.ord.check_ord")
-    def test_ord_upgrade(self, mock_check_ord, mock_get_version, mock_helm_check,
-                         mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
-        mock_get_version.side_effect = [
-            "ord-version",
-        ]
-        mock_helm_extra_vars.side_effect = [
-            "extra-vars-ord0",
-        ]
+    def test_ord_upgrade(
+        self,
+        mock_check_ord,
+        mock_get_version,
+        mock_helm_check,
+        mock_helm_extra_vars,
+        mock_helm_install,
+        mock_helm_upgrade,
+    ):
+        mock_get_version.side_effect = ["ord-version"]
+        mock_helm_extra_vars.side_effect = ["extra-vars-ord0"]
         setup_ord(self.OPTS, upgrade=True)
-        mock_get_version.assert_has_calls([
-            call(self.OPTS, "hlf-ord")
-        ])
-        mock_helm_extra_vars.assert_has_calls([
-            call(version="ord-version",
-                 config_yaml="./a_dir/hlf-ord/ord0.yaml")
-        ])
+        mock_get_version.assert_has_calls([call(self.OPTS, "hlf-ord")])
+        mock_helm_extra_vars.assert_has_calls(
+            [call(version="ord-version", config_yaml="./a_dir/hlf-ord/ord0.yaml")]
+        )
         mock_helm_install.assert_not_called()
         mock_helm_upgrade.assert_called_once_with(
-            "a-repo",
-            "hlf-ord",
-            "ord0",
-            extra_vars="extra-vars-ord0",
-            verbose=False,
+            "a-repo", "hlf-ord", "ord0", extra_vars="extra-vars-ord0", verbose=False
         )
         mock_check_ord.assert_called_once_with("ord-namespace", "ord0", verbose=False)
-        mock_helm_check.assert_has_calls([
-            call("hlf-ord", "ord0", "ord-namespace"),
-        ])
+        mock_helm_check.assert_has_calls([call("hlf-ord", "ord0", "ord-namespace")])

--- a/tests/fabric/test_ord.py
+++ b/tests/fabric/test_ord.py
@@ -72,7 +72,15 @@ class TestSetupOrd:
                  mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         OPTS["orderers"]["names"] = ["ord0", "ord1"]
+        mock_helm_extra_vars.side_effect = [
+            "extra-vars-ord0",
+            "extra-vars-ord1"
+        ]
         setup_ord(OPTS)
+        mock_helm_extra_vars.assert_has_calls([
+            call(config_yaml="./a_dir/hlf-ord/ord0.yaml"),
+            call(config_yaml="./a_dir/hlf-ord/ord1.yaml")
+        ])
         mock_helm_install.assert_has_calls(
             [
                 call(
@@ -80,7 +88,7 @@ class TestSetupOrd:
                     "hlf-ord",
                     "ord0",
                     "ord-namespace",
-                    config_yaml="./a_dir/hlf-ord/ord0.yaml",
+                    extra_vars="extra-vars-ord0",
                     verbose=False,
                 ),
                 call(
@@ -88,7 +96,7 @@ class TestSetupOrd:
                     "hlf-ord",
                     "ord1",
                     "ord-namespace",
-                    config_yaml="./a_dir/hlf-ord/ord1.yaml",
+                    extra_vars="extra-vars-ord1",
                     verbose=False,
                 ),
             ]
@@ -114,7 +122,15 @@ class TestSetupOrd:
                        mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         OPTS["orderers"]["kafka"] = {"pod_num": 42}
+        mock_helm_extra_vars.side_effect = [
+            "extra-vars-kafka",
+            "extra-vars-ord0",
+        ]
         setup_ord(OPTS, verbose=True)
+        mock_helm_extra_vars.assert_has_calls([
+            call(config_yaml="./a_dir/kafka/kafka-hlf.yaml"),
+            call(config_yaml="./a_dir/hlf-ord/ord0.yaml")
+        ])
         mock_helm_install.assert_has_calls(
             [
                 call(
@@ -122,7 +138,7 @@ class TestSetupOrd:
                     "kafka",
                     "kafka-hlf",
                     "ord-namespace",
-                    config_yaml="./a_dir/kafka/kafka-hlf.yaml",
+                    extra_vars="extra-vars-kafka",
                     verbose=True,
                 ),
                 call(
@@ -130,7 +146,7 @@ class TestSetupOrd:
                     "hlf-ord",
                     "ord0",
                     "ord-namespace",
-                    config_yaml="./a_dir/hlf-ord/ord0.yaml",
+                    extra_vars="extra-vars-ord0",
                     verbose=True,
                 ),
             ]
@@ -149,14 +165,19 @@ class TestSetupOrd:
     @patch("nephos.fabric.ord.check_ord")
     def test_ord_upgrade(self, mock_check_ord, mock_helm_check,
                          mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
+        mock_helm_extra_vars.side_effect = [
+            "extra-vars-ord0",
+        ]
         setup_ord(self.OPTS, upgrade=True)
+        mock_helm_extra_vars.assert_has_calls([
+            call(config_yaml="./a_dir/hlf-ord/ord0.yaml")
+        ])
         mock_helm_install.assert_not_called()
         mock_helm_upgrade.assert_called_once_with(
             "a-repo",
             "hlf-ord",
             "ord0",
-            "ord-namespace",
-            config_yaml="./a_dir/hlf-ord/ord0.yaml",
+            extra_vars="extra-vars-ord0",
             verbose=False,
         )
         mock_check_ord.assert_called_once_with("ord-namespace", "ord0", verbose=False)

--- a/tests/fabric/test_peer.py
+++ b/tests/fabric/test_peer.py
@@ -133,11 +133,13 @@ class TestSetupPeer:
                     config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
                     preserve=(
                         HelmPreserve(
+                            "peer-namespace",
                             "cdb-peer0-hlf-couchdb",
                             "COUCHDB_USERNAME",
                             "couchdbUsername",
                         ),
                         HelmPreserve(
+                            "peer-namespace",
                             "cdb-peer0-hlf-couchdb",
                             "COUCHDB_PASSWORD",
                             "couchdbPassword",

--- a/tests/fabric/test_peer.py
+++ b/tests/fabric/test_peer.py
@@ -63,28 +63,43 @@ class TestSetupPeer:
     @patch("nephos.fabric.peer.helm_check")
     @patch("nephos.fabric.peer.get_version")
     @patch("nephos.fabric.peer.check_peer")
-    def test_peer(self, mock_check_peer, mock_get_version, mock_helm_check,
-                  mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
+    def test_peer(
+        self,
+        mock_check_peer,
+        mock_get_version,
+        mock_helm_check,
+        mock_helm_extra_vars,
+        mock_helm_install,
+        mock_helm_upgrade,
+    ):
         OPTS = deepcopy(self.OPTS)
         mock_get_version.side_effect = [
             "cdb-version",
             "peer-version",
             "cdb-version",
-            "peer-version"
+            "peer-version",
         ]
         mock_helm_extra_vars.side_effect = [
             "extra-vars-cdb-peer0",
             "extra-vars-peer0",
             "extra-vars-cdb-peer1",
-            "extra-vars-peer1"
+            "extra-vars-peer1",
         ]
         setup_peer(OPTS)
-        mock_helm_extra_vars.assert_has_calls([
-            call(version="cdb-version", config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml"),
-            call(version="peer-version", config_yaml="./a_dir/hlf-peer/peer0.yaml"),
-            call(version="cdb-version", config_yaml="./a_dir/hlf-couchdb/cdb-peer1.yaml",),
-            call(version="peer-version", config_yaml="./a_dir/hlf-peer/peer1.yaml")
-        ])
+        mock_helm_extra_vars.assert_has_calls(
+            [
+                call(
+                    version="cdb-version",
+                    config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
+                ),
+                call(version="peer-version", config_yaml="./a_dir/hlf-peer/peer0.yaml"),
+                call(
+                    version="cdb-version",
+                    config_yaml="./a_dir/hlf-couchdb/cdb-peer1.yaml",
+                ),
+                call(version="peer-version", config_yaml="./a_dir/hlf-peer/peer1.yaml"),
+            ]
+        )
         mock_helm_install.assert_has_calls(
             [
                 call(
@@ -122,12 +137,14 @@ class TestSetupPeer:
             ]
         )
         mock_helm_upgrade.assert_not_called()
-        mock_helm_check.assert_has_calls([
-            call("hlf-couchdb", "cdb-peer0", "peer-namespace"),
-            call("hlf-peer", "peer0", "peer-namespace"),
-            call("hlf-couchdb", "cdb-peer1", "peer-namespace"),
-            call("hlf-peer", "peer1", "peer-namespace"),
-        ])
+        mock_helm_check.assert_has_calls(
+            [
+                call("hlf-couchdb", "cdb-peer0", "peer-namespace"),
+                call("hlf-peer", "peer0", "peer-namespace"),
+                call("hlf-couchdb", "cdb-peer1", "peer-namespace"),
+                call("hlf-peer", "peer1", "peer-namespace"),
+            ]
+        )
         mock_check_peer.assert_has_calls(
             [
                 call("peer-namespace", "peer0", verbose=False),
@@ -141,23 +158,26 @@ class TestSetupPeer:
     @patch("nephos.fabric.peer.helm_check")
     @patch("nephos.fabric.peer.get_version")
     @patch("nephos.fabric.peer.check_peer")
-    def test_peer_upgrade(self, mock_check_peer, mock_get_version, mock_helm_check,
-                          mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
+    def test_peer_upgrade(
+        self,
+        mock_check_peer,
+        mock_get_version,
+        mock_helm_check,
+        mock_helm_extra_vars,
+        mock_helm_install,
+        mock_helm_upgrade,
+    ):
         OPTS = deepcopy(self.OPTS)
         OPTS["peers"]["names"] = ["peer0"]
-        mock_get_version.side_effect = [
-            "cdb-version",
-            "peer-version",
-        ]
-        mock_helm_extra_vars.side_effect = [
-            "extra-vars-cdb-peer0",
-            "extra-vars-peer0"
-        ]
+        mock_get_version.side_effect = ["cdb-version", "peer-version"]
+        mock_helm_extra_vars.side_effect = ["extra-vars-cdb-peer0", "extra-vars-peer0"]
         setup_peer(OPTS, upgrade=True)
-        mock_helm_extra_vars.assert_has_calls([
-            call(version="cdb-version",
-                 config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
-                 preserve=(
+        mock_helm_extra_vars.assert_has_calls(
+            [
+                call(
+                    version="cdb-version",
+                    config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
+                    preserve=(
                         HelmPreserve(
                             "peer-namespace",
                             "cdb-peer0-hlf-couchdb",
@@ -170,10 +190,11 @@ class TestSetupPeer:
                             "COUCHDB_PASSWORD",
                             "couchdbPassword",
                         ),
-                    )),
-            call(version="peer-version",
-                 config_yaml="./a_dir/hlf-peer/peer0.yaml")
-        ])
+                    ),
+                ),
+                call(version="peer-version", config_yaml="./a_dir/hlf-peer/peer0.yaml"),
+            ]
+        )
         mock_helm_install.assert_not_called()
         mock_helm_upgrade.assert_has_calls(
             [
@@ -193,10 +214,12 @@ class TestSetupPeer:
                 ),
             ]
         )
-        mock_helm_check.assert_has_calls([
-            call("hlf-couchdb", "cdb-peer0", "peer-namespace"),
-            call("hlf-peer", "peer0", "peer-namespace"),
-        ])
+        mock_helm_check.assert_has_calls(
+            [
+                call("hlf-couchdb", "cdb-peer0", "peer-namespace"),
+                call("hlf-peer", "peer0", "peer-namespace"),
+            ]
+        )
         mock_check_peer.assert_called_once_with(
             "peer-namespace", "peer0", verbose=False
         )

--- a/tests/fabric/test_peer.py
+++ b/tests/fabric/test_peer.py
@@ -59,8 +59,9 @@ class TestSetupPeer:
 
     @patch("nephos.fabric.peer.helm_upgrade")
     @patch("nephos.fabric.peer.helm_install")
+    @patch("nephos.fabric.peer.helm_check")
     @patch("nephos.fabric.peer.check_peer")
-    def test_peer(self, mock_check_peer, mock_helm_install, mock_helm_upgrade):
+    def test_peer(self, mock_check_peer, mock_helm_check, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         setup_peer(OPTS)
         mock_helm_install.assert_has_calls(
@@ -100,6 +101,12 @@ class TestSetupPeer:
             ]
         )
         mock_helm_upgrade.assert_not_called()
+        mock_helm_check.assert_has_calls([
+            call("hlf-couchdb", "cdb-peer0", "peer-namespace"),
+            call("hlf-peer", "peer0", "peer-namespace"),
+            call("hlf-couchdb", "cdb-peer1", "peer-namespace"),
+            call("hlf-peer", "peer1", "peer-namespace"),
+        ])
         mock_check_peer.assert_has_calls(
             [
                 call("peer-namespace", "peer0", verbose=False),
@@ -109,8 +116,9 @@ class TestSetupPeer:
 
     @patch("nephos.fabric.peer.helm_upgrade")
     @patch("nephos.fabric.peer.helm_install")
+    @patch("nephos.fabric.peer.helm_check")
     @patch("nephos.fabric.peer.check_peer")
-    def test_peer_upgrade(self, mock_check_peer, mock_helm_install, mock_helm_upgrade):
+    def test_peer_upgrade(self, mock_check_peer, mock_helm_check, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         OPTS["peers"]["names"] = ["peer0"]
         setup_peer(OPTS, upgrade=True)
@@ -147,6 +155,10 @@ class TestSetupPeer:
                 ),
             ]
         )
+        mock_helm_check.assert_has_calls([
+            call("hlf-couchdb", "cdb-peer0", "peer-namespace"),
+            call("hlf-peer", "peer0", "peer-namespace"),
+        ])
         mock_check_peer.assert_called_once_with(
             "peer-namespace", "peer0", verbose=False
         )

--- a/tests/fabric/test_peer.py
+++ b/tests/fabric/test_peer.py
@@ -59,9 +59,11 @@ class TestSetupPeer:
 
     @patch("nephos.fabric.peer.helm_upgrade")
     @patch("nephos.fabric.peer.helm_install")
+    @patch("nephos.fabric.peer.helm_extra_vars")
     @patch("nephos.fabric.peer.helm_check")
     @patch("nephos.fabric.peer.check_peer")
-    def test_peer(self, mock_check_peer, mock_helm_check, mock_helm_install, mock_helm_upgrade):
+    def test_peer(self, mock_check_peer, mock_helm_check,
+                  mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         setup_peer(OPTS)
         mock_helm_install.assert_has_calls(
@@ -116,9 +118,11 @@ class TestSetupPeer:
 
     @patch("nephos.fabric.peer.helm_upgrade")
     @patch("nephos.fabric.peer.helm_install")
+    @patch("nephos.fabric.peer.helm_extra_vars")
     @patch("nephos.fabric.peer.helm_check")
     @patch("nephos.fabric.peer.check_peer")
-    def test_peer_upgrade(self, mock_check_peer, mock_helm_check, mock_helm_install, mock_helm_upgrade):
+    def test_peer_upgrade(self, mock_check_peer, mock_helm_check,
+                          mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         OPTS["peers"]["names"] = ["peer0"]
         setup_peer(OPTS, upgrade=True)

--- a/tests/fabric/test_peer.py
+++ b/tests/fabric/test_peer.py
@@ -65,7 +65,19 @@ class TestSetupPeer:
     def test_peer(self, mock_check_peer, mock_helm_check,
                   mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
+        mock_helm_extra_vars.side_effect = [
+            "extra-vars-cdb-peer0",
+            "extra-vars-peer0",
+            "extra-vars-cdb-peer1",
+            "extra-vars-peer1"
+        ]
         setup_peer(OPTS)
+        mock_helm_extra_vars.assert_has_calls([
+            call(config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml"),
+            call(config_yaml="./a_dir/hlf-peer/peer0.yaml"),
+            call(config_yaml="./a_dir/hlf-couchdb/cdb-peer1.yaml",),
+            call(config_yaml="./a_dir/hlf-peer/peer1.yaml")
+        ])
         mock_helm_install.assert_has_calls(
             [
                 call(
@@ -73,7 +85,7 @@ class TestSetupPeer:
                     "hlf-couchdb",
                     "cdb-peer0",
                     "peer-namespace",
-                    config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
+                    extra_vars="extra-vars-cdb-peer0",
                     verbose=False,
                 ),
                 call(
@@ -81,7 +93,7 @@ class TestSetupPeer:
                     "hlf-peer",
                     "peer0",
                     "peer-namespace",
-                    config_yaml="./a_dir/hlf-peer/peer0.yaml",
+                    extra_vars="extra-vars-peer0",
                     verbose=False,
                 ),
                 call(
@@ -89,7 +101,7 @@ class TestSetupPeer:
                     "hlf-couchdb",
                     "cdb-peer1",
                     "peer-namespace",
-                    config_yaml="./a_dir/hlf-couchdb/cdb-peer1.yaml",
+                    extra_vars="extra-vars-cdb-peer1",
                     verbose=False,
                 ),
                 call(
@@ -97,7 +109,7 @@ class TestSetupPeer:
                     "hlf-peer",
                     "peer1",
                     "peer-namespace",
-                    config_yaml="./a_dir/hlf-peer/peer1.yaml",
+                    extra_vars="extra-vars-peer1",
                     verbose=False,
                 ),
             ]
@@ -125,17 +137,14 @@ class TestSetupPeer:
                           mock_helm_extra_vars, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
         OPTS["peers"]["names"] = ["peer0"]
+        mock_helm_extra_vars.side_effect = [
+            "extra-vars-cdb-peer0",
+            "extra-vars-peer0"
+        ]
         setup_peer(OPTS, upgrade=True)
-        mock_helm_install.assert_not_called()
-        mock_helm_upgrade.assert_has_calls(
-            [
-                call(
-                    "a-repo",
-                    "hlf-couchdb",
-                    "cdb-peer0",
-                    "peer-namespace",
-                    config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
-                    preserve=(
+        mock_helm_extra_vars.assert_has_calls([
+            call(config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
+                 preserve=(
                         HelmPreserve(
                             "peer-namespace",
                             "cdb-peer0-hlf-couchdb",
@@ -148,15 +157,24 @@ class TestSetupPeer:
                             "COUCHDB_PASSWORD",
                             "couchdbPassword",
                         ),
-                    ),
+                    )),
+            call(config_yaml="./a_dir/hlf-peer/peer0.yaml")
+        ])
+        mock_helm_install.assert_not_called()
+        mock_helm_upgrade.assert_has_calls(
+            [
+                call(
+                    "a-repo",
+                    "hlf-couchdb",
+                    "cdb-peer0",
+                    extra_vars="extra-vars-cdb-peer0",
                     verbose=False,
                 ),
                 call(
                     "a-repo",
                     "hlf-peer",
                     "peer0",
-                    "peer-namespace",
-                    config_yaml="./a_dir/hlf-peer/peer0.yaml",
+                    extra_vars="extra-vars-peer0",
                     verbose=False,
                 ),
             ]

--- a/tests/fabric/test_settings.py
+++ b/tests/fabric/test_settings.py
@@ -7,6 +7,7 @@ from nephos.fabric.settings import (
     dict_representer,
     check_cluster,
     get_namespace,
+    get_version,
     load_config,
 )
 
@@ -80,6 +81,22 @@ class TestGetNamespace:
     def test_get_namespace_ca_error(self):
         with pytest.raises(KeyError):
             get_namespace(self.OPTS, ca="nonexistent-ca")
+
+
+class TestGetVersion:
+    OPTS = {"versions": {"versioned-app": "a-version", "unversioned-app": None}}
+
+    def test_get_version(self):
+        result = get_version(self.OPTS, "versioned-app")
+        assert result == "a-version"
+
+    def test_get_version_none(self):
+        result = get_version(self.OPTS, "unversioned-app")
+        assert result is None
+
+    def test_get_version_unknown(self):
+        result = get_version(self.OPTS, "unknown-app")
+        assert result is None
 
 
 class TestLoadHlfConfig:

--- a/tests/helpers/test_helm.py
+++ b/tests/helpers/test_helm.py
@@ -53,12 +53,16 @@ class TestHelmCheck:
     @patch("nephos.helpers.helm.pod_check")
     def test_helm_check(self, mock_pod_check):
         helm_check("an_app", "a-release", "a-namespace")
-        mock_pod_check.assert_called_once_with("a-namespace", '-l "app=an_app,release=a-release"', pod_num=None)
+        mock_pod_check.assert_called_once_with(
+            "a-namespace", '-l "app=an_app,release=a-release"', pod_num=None
+        )
 
     @patch("nephos.helpers.helm.pod_check")
     def test_helm_check_podnum(self, mock_pod_check):
         helm_check("an_app", "a-release", "a-namespace", pod_num=2)
-        mock_pod_check.assert_called_once_with("a-namespace", '-l "app=an_app,release=a-release"', pod_num=2)
+        mock_pod_check.assert_called_once_with(
+            "a-namespace", '-l "app=an_app,release=a-release"', pod_num=2
+        )
 
 
 class TestHelmEnvVars:
@@ -120,11 +124,19 @@ class TestHelmExtraVars:
     def test_helm_extra_vars_everything(self, mock_helm_env_vars, mock_helm_preserve):
         mock_helm_env_vars.side_effect = [" --set foo=bar"]
         mock_helm_preserve.side_effect = [" --set egg=sausage"]
-        result = helm_extra_vars(version="a-version", config_yaml="some-config",
-                                 env_vars="some-env-vars", preserve="some-preserve", verbose=True)
+        result = helm_extra_vars(
+            version="a-version",
+            config_yaml="some-config",
+            env_vars="some-env-vars",
+            preserve="some-preserve",
+            verbose=True,
+        )
         mock_helm_env_vars.assert_called_once_with("some-env-vars")
         mock_helm_preserve.assert_called_once_with("some-preserve", verbose=True)
-        assert result == " --version a-version -f some-config --set foo=bar --set egg=sausage"
+        assert (
+            result
+            == " --version a-version -f some-config --set foo=bar --set egg=sausage"
+        )
 
     @patch("nephos.helpers.helm.helm_preserve")
     @patch("nephos.helpers.helm.helm_env_vars")
@@ -162,34 +174,26 @@ class TestHelmInstall:
         )
 
     @patch("nephos.helpers.helm.execute")
-    def test_helm_install_again(
-        self, mock_execute
-    ):
+    def test_helm_install_again(self, mock_execute):
         mock_execute.side_effect = [("a-release", None)]  # Helm list
         helm_install("a_repo", "an_app", "a-release", "a-namespace")
         mock_execute.assert_called_once_with("helm status a-release")
 
     @patch("nephos.helpers.helm.execute")
-    def test_helm_install_extra(
-        self, mock_execute
-    ):
+    def test_helm_install_extra(self, mock_execute):
         mock_execute.side_effect = [
             (None, "error"),  # Helm list
             ("Helm install", None),  # Helm install
         ]
         helm_install(
-            "a_repo",
-            "an_app",
-            "a-release",
-            "a-namespace",
-            extra_vars=" EXTRA-VARS",
+            "a_repo", "an_app", "a-release", "a-namespace", extra_vars=" EXTRA-VARS"
         )
         mock_execute.assert_has_calls(
             [
                 call("helm status a-release"),
                 call(
-                    "helm install a_repo/an_app -n a-release " +
-                    "--namespace a-namespace EXTRA-VARS",
+                    "helm install a_repo/an_app -n a-release "
+                    + "--namespace a-namespace EXTRA-VARS",
                     verbose=False,
                 ),
             ]
@@ -198,9 +202,7 @@ class TestHelmInstall:
 
 class TestHelmUpgrade:
     @patch("nephos.helpers.helm.execute")
-    def test_helm_upgrade(
-        self, mock_execute
-    ):
+    def test_helm_upgrade(self, mock_execute):
         mock_execute.side_effect = [
             ("a-release", None),  # Helm list
             ("Helm install", None),  # Helm install
@@ -214,34 +216,22 @@ class TestHelmUpgrade:
         )
 
     @patch("nephos.helpers.helm.execute")
-    def test_helm_upgrade_preinstall(
-        self, mock_execute
-    ):
+    def test_helm_upgrade_preinstall(self, mock_execute):
         mock_execute.side_effect = [(None, "error")]  # Helm list
         with pytest.raises(Exception):
             helm_upgrade("a_repo", "an_app", "a-release")
         mock_execute.assert_called_once_with("helm status a-release")
 
     @patch("nephos.helpers.helm.execute")
-    def test_helm_upgrade_extra_vars(
-        self, mock_execute
-    ):
+    def test_helm_upgrade_extra_vars(self, mock_execute):
         mock_execute.side_effect = [
             ("a-release", None),  # Helm list
             ("Helm upgrade", None),  # Helm upgrade
         ]
-        helm_upgrade(
-            "a_repo",
-            "an_app",
-            "a-release",
-            extra_vars=" EXTRA-VARS"
-        )
+        helm_upgrade("a_repo", "an_app", "a-release", extra_vars=" EXTRA-VARS")
         mock_execute.assert_has_calls(
             [
                 call("helm status a-release"),
-                call(
-                    "helm upgrade a-release a_repo/an_app EXTRA-VARS",
-                    verbose=False,
-                ),
+                call("helm upgrade a-release a_repo/an_app EXTRA-VARS", verbose=False),
             ]
         )

--- a/tests/helpers/test_helm.py
+++ b/tests/helpers/test_helm.py
@@ -114,9 +114,8 @@ class TestHelmPreserve:
 
 class TestHelmInstall:
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
-    def test_helm_install(self, mock_execute, mock_helm_check, mock_helm_env_vars):
+    def test_helm_install(self, mock_execute, mock_helm_env_vars):
         mock_helm_env_vars.side_effect = [""]
         mock_execute.side_effect = [
             (None, "error"),  # Helm list
@@ -133,26 +132,22 @@ class TestHelmInstall:
                 ),
             ]
         )
-        mock_helm_check.assert_called_once_with("an_app", "a-release", "a-namespace", 1)
 
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
     def test_helm_install_again(
-        self, mock_execute, mock_helm_check, mock_helm_env_vars
+        self, mock_execute, mock_helm_env_vars
     ):
         mock_helm_env_vars.side_effect = [""]
         mock_execute.side_effect = [("a-release", None)]  # Helm list
         helm_install("a_repo", "an_app", "a-release", "a-namespace")
         mock_helm_env_vars.assert_called_once_with(None)
         mock_execute.assert_called_once_with("helm status a-release")
-        mock_helm_check.assert_called_once_with("an_app", "a-release", "a-namespace", 1)
 
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
     def test_helm_install_config(
-        self, mock_execute, mock_helm_check, mock_helm_env_vars
+        self, mock_execute, mock_helm_env_vars
     ):
         mock_helm_env_vars.side_effect = [""]
         mock_execute.side_effect = [
@@ -178,13 +173,11 @@ class TestHelmInstall:
                 ),
             ]
         )
-        mock_helm_check.assert_called_once_with("an_app", "a-release", "a-namespace", 1)
 
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
     def test_helm_install_envvars(
-        self, mock_execute, mock_helm_check, mock_helm_env_vars
+        self, mock_execute, mock_helm_env_vars
     ):
         mock_helm_env_vars.side_effect = [" --set foo=bar"]
         mock_execute.side_effect = [
@@ -210,16 +203,14 @@ class TestHelmInstall:
                 ),
             ]
         )
-        mock_helm_check.assert_called_once_with("an_app", "a-release", "a-namespace", 1)
 
 
 class TestHelmUpgrade:
     @patch("nephos.helpers.helm.helm_preserve")
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
     def test_helm_upgrade(
-        self, mock_execute, mock_helm_check, mock_helm_env_vars, mock_helm_preserve
+        self, mock_execute, mock_helm_env_vars, mock_helm_preserve
     ):
         mock_helm_env_vars.side_effect = [""]
         mock_helm_preserve.side_effect = [""]
@@ -236,14 +227,12 @@ class TestHelmUpgrade:
                 call("helm upgrade a-release a_repo/an_app", verbose=False),
             ]
         )
-        mock_helm_check.assert_called_once_with("an_app", "a-release", "a-namespace", 1)
 
     @patch("nephos.helpers.helm.helm_preserve")
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
     def test_helm_upgrade_preinstall(
-        self, mock_execute, mock_helm_check, mock_helm_env_vars, mock_helm_preserve
+        self, mock_execute, mock_helm_env_vars, mock_helm_preserve
     ):
         mock_helm_env_vars.side_effect = [""]
         mock_helm_preserve.side_effect = [""]
@@ -253,14 +242,12 @@ class TestHelmUpgrade:
         mock_helm_env_vars.assert_called_once_with(None)
         mock_helm_preserve.assert_called_once_with("a-namespace", None, verbose=False)
         mock_execute.assert_called_once_with("helm status a-release")
-        mock_helm_check.assert_not_called()
 
     @patch("nephos.helpers.helm.helm_preserve")
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
     def test_helm_upgrade_config(
-        self, mock_execute, mock_helm_check, mock_helm_env_vars, mock_helm_preserve
+        self, mock_execute, mock_helm_env_vars, mock_helm_preserve
     ):
         mock_helm_env_vars.side_effect = [""]
         mock_helm_preserve.side_effect = [""]
@@ -288,14 +275,12 @@ class TestHelmUpgrade:
                 ),
             ]
         )
-        mock_helm_check.assert_called_once_with("an_app", "a-release", "a-namespace", 1)
 
     @patch("nephos.helpers.helm.helm_preserve")
     @patch("nephos.helpers.helm.helm_env_vars")
-    @patch("nephos.helpers.helm.helm_check")
     @patch("nephos.helpers.helm.execute")
     def test_helm_upgrade_preserve(
-        self, mock_execute, mock_helm_check, mock_helm_env_vars, mock_helm_preserve
+        self, mock_execute, mock_helm_env_vars, mock_helm_preserve
     ):
         mock_helm_env_vars.side_effect = [" --set foo=bar"]
         mock_helm_preserve.side_effect = [" --set egg=sausage"]
@@ -325,4 +310,3 @@ class TestHelmUpgrade:
                 ),
             ]
         )
-        mock_helm_check.assert_called_once_with("an_app", "a-release", "a-namespace", 1)

--- a/tests/helpers/test_helm.py
+++ b/tests/helpers/test_helm.py
@@ -164,6 +164,7 @@ class TestHelmInstall:
             "an_app",
             "a-release",
             "a-namespace",
+            version="a-version",
             config_yaml="some_config.yaml",
         )
         mock_helm_env_vars.assert_called_once_with(None)
@@ -171,7 +172,8 @@ class TestHelmInstall:
             [
                 call("helm status a-release"),
                 call(
-                    "helm install a_repo/an_app -n a-release --namespace a-namespace -f some_config.yaml",
+                    "helm install a_repo/an_app -n a-release " +
+                    "--namespace a-namespace --version a-version -f some_config.yaml",
                     verbose=False,
                 ),
             ]
@@ -271,6 +273,7 @@ class TestHelmUpgrade:
             "an_app",
             "a-release",
             "a-namespace",
+            version="a-version",
             config_yaml="some_config.yaml",
         )
         mock_helm_env_vars.assert_called_once_with(None)
@@ -279,7 +282,8 @@ class TestHelmUpgrade:
             [
                 call("helm status a-release"),
                 call(
-                    "helm upgrade a-release a_repo/an_app -f some_config.yaml",
+                    "helm upgrade a-release a_repo/an_app " +
+                    "--version a-version -f some_config.yaml",
                     verbose=False,
                 ),
             ]

--- a/tests/helpers/test_k8s.py
+++ b/tests/helpers/test_k8s.py
@@ -216,10 +216,7 @@ class TestPodCheck:
     @patch("nephos.helpers.k8s.print")
     @patch("nephos.helpers.k8s.execute")
     def test_helm_check(self, mock_execute, mock_print, mock_sleep):
-        mock_execute.side_effect = [
-            ("Pending", None),  # Get states
-            ("Running", None),
-        ]
+        mock_execute.side_effect = [("Pending", None), ("Running", None)]  # Get states
         pod_check("a-namespace", "an-identifier", sleep_interval=15)
         assert mock_execute.call_count == 2
         mock_print.assert_has_calls(


### PR DESCRIPTION
Enable the possibility of doing versioned installs, where we can specify Helm versions for all the components of the network in the Nephos configuration YAML.

Also remove 2 code smells from SonarQube by refactoring the helm_install and help_upgrade commands, resulting in the new helper helm_extra_vars.

This has breaking changes compared to version 0.2.x, so is updated to 0.3.0, but functionality remains similar.