### PR TITLE
Update hardcoded kafka release name

### DIFF
--- a/examples/prod/nephos_config.yaml
+++ b/examples/prod/nephos_config.yaml
@@ -34,6 +34,7 @@ orderers:
   - ord2
   secret_genesis: hlf--genesis
   kafka:
+    name: kafka-hlf
     pod_num: 4
 peers:
   domain: peers.svc.cluster.local

--- a/nephos/fabric/ord.py
+++ b/nephos/fabric/ord.py
@@ -82,10 +82,10 @@ def setup_ord(opts, upgrade=False, verbose=False):
         helm_install(
             "incubator",
             "kafka",
-            "kafka-hlf",
+            opts["orderers"]["kafka"]["name"],
             ord_namespace,
-            config_yaml="{dir}/kafka/kafka-hlf.yaml".format(
-                dir=opts["core"]["dir_values"]
+            config_yaml="{dir}/kafka/{release}.yaml".format(
+                dir=opts["core"]["dir_values"], release=opts["orderers"]["kafka"]["name"]
             ),
             pod_num=opts["orderers"]["kafka"]["pod_num"],
             verbose=verbose,

--- a/tests/fabric/test_ord.py
+++ b/tests/fabric/test_ord.py
@@ -103,7 +103,7 @@ class TestSetupOrd:
     @patch("nephos.fabric.ord.check_ord")
     def test_ord_kafka(self, mock_check_ord, mock_helm_install, mock_helm_upgrade):
         OPTS = deepcopy(self.OPTS)
-        OPTS["orderers"]["kafka"] = {"pod_num": 42}
+        OPTS["orderers"]["kafka"] = {"name": "kafka-hlf", "pod_num": 42}
         setup_ord(OPTS, verbose=True)
         mock_helm_install.assert_has_calls(
             [


### PR DESCRIPTION
This replaces the hardcoded value with user-specified ones, allowing to have multiple Kafka deployments.