### PR TITLE
[HOTFIX] Fix missing verbosity argument from methods.

### DIFF
--- a/nephos/composer/install.py
+++ b/nephos/composer/install.py
@@ -50,8 +50,7 @@ def get_composer_data(opts, verbose=False):
         peer_namespace,
         composer_name,
         composer_name,
-        secret_key="COMPOSER_APIKEY",
-        verbose=verbose,
+        secret_key="COMPOSER_APIKEY"
     )
     return data
 
@@ -71,11 +70,11 @@ def composer_connection(opts, verbose=False):
     peer_ca = opts["msps"][peer_msp]["ca"]
     ca_namespace = opts["cas"][peer_ca]["namespace"]
     ingress_urls = ingress_read(
-        peer_ca + "-hlf-ca", namespace=ca_namespace, verbose=verbose
+        peer_ca + "-hlf-ca", namespace=ca_namespace
     )
     peer_ca_url = ingress_urls[0]
     try:
-        cm_read(opts["composer"]["secret_connection"], peer_namespace, verbose=verbose)
+        cm_read(opts["composer"]["secret_connection"], peer_namespace)
     except ApiException:
         # Set up connection.json
         # TODO: Improve json_ct to work entirely with opts structure
@@ -94,7 +93,6 @@ def composer_connection(opts, verbose=False):
             cm_data,
             opts["composer"]["secret_connection"],
             peer_namespace,
-            verbose=verbose,
         )
 
 
@@ -113,7 +111,7 @@ def deploy_composer(opts, upgrade=False, verbose=False):
     peer_namespace = get_namespace(opts, opts["peers"]["msp"])
     # Ensure BNA exists
     secret_from_file(
-        secret=opts["composer"]["secret_bna"], namespace=peer_namespace, verbose=verbose
+        secret=opts["composer"]["secret_bna"], namespace=peer_namespace
     )
     composer_connection(opts, verbose=verbose)
 
@@ -127,8 +125,7 @@ def deploy_composer(opts, upgrade=False, verbose=False):
             "hl-composer",
             opts["composer"]["name"],
             peer_namespace,
-            extra_vars=extra_vars,
-            verbose=verbose,
+            extra_vars=extra_vars
         )
     else:
         preserve = (
@@ -146,8 +143,7 @@ def deploy_composer(opts, upgrade=False, verbose=False):
             opts["core"]["chart_repo"],
             "hl-composer",
             opts["composer"]["name"],
-            extra_vars=extra_vars,
-            verbose=verbose,
+            extra_vars=extra_vars
         )
     helm_check("hl-composer", opts["composer"]["name"], peer_namespace, pod_num=3)
 
@@ -166,7 +162,7 @@ def setup_card(opts, msp_path, user_name, roles, network=None, verbose=False):
 
     peer_namespace = get_namespace(opts, opts["peers"]["msp"])
     hlc_cli_ex = get_helm_pod(
-        peer_namespace, opts["composer"]["name"], "hl-composer", verbose=verbose
+        peer_namespace, opts["composer"]["name"], "hl-composer"
     )
 
     # Set up the PeerAdmin card
@@ -222,7 +218,7 @@ def install_network(opts, verbose=False):
     """
     peer_namespace = get_namespace(opts, opts["peers"]["msp"])
     hlc_cli_ex = get_helm_pod(
-        peer_namespace, opts["composer"]["name"], "hl-composer", verbose=verbose
+        peer_namespace, opts["composer"]["name"], "hl-composer"
     )
 
     # Install network
@@ -233,7 +229,7 @@ def install_network(opts, verbose=False):
     # TODO: This could be a single function
     peer_msp = opts["peers"]["msp"]
     bna_admin = opts["msps"][peer_msp]["org_admin"]
-    admin_creds(opts, peer_msp, verbose=verbose)
+    admin_creds(opts, peer_msp)
     bna_pw = opts["msps"][peer_msp]["org_adminpw"]
 
     ls_res, _ = hlc_cli_ex.execute(
@@ -259,6 +255,8 @@ def install_network(opts, verbose=False):
             f"composer card import --file {bna_admin}@{bna_name}.card"
         )
 
+    # TODO: This step sometimes fail, maybe needs some try logic to test it,
+    # executing it manually after a minute succeeds.
     hlc_cli_ex.execute(
         f"composer network ping --card {bna_admin}@{bna_name}"
     )

--- a/nephos/fabric/ca.py
+++ b/nephos/fabric/ca.py
@@ -127,6 +127,8 @@ def ca_enroll(pod_exec):
         else:
             sleep(15)
     # Enroll CA Admin if necessary
+
+    # TODO: Add verification for pem file.
     ca_cert, _ = pod_exec.execute(
         "cat /var/hyperledger/fabric-ca/msp/signcerts/cert.pem"
     )

--- a/tests/composer/test_install.py
+++ b/tests/composer/test_install.py
@@ -29,8 +29,7 @@ class TestGetComposerData:
             "peer-namespace",
             "hlc-hl-composer-rest",
             "hlc-hl-composer-rest",
-            secret_key="COMPOSER_APIKEY",
-            verbose=False,
+            secret_key="COMPOSER_APIKEY"
         )
 
     @patch("nephos.composer.install.get_app_info")
@@ -42,8 +41,7 @@ class TestGetComposerData:
             "peer-namespace",
             "hlc-hl-composer-rest",
             "hlc-hl-composer-rest",
-            secret_key="COMPOSER_APIKEY",
-            verbose=True,
+            secret_key="COMPOSER_APIKEY"
         )
 
 
@@ -70,17 +68,16 @@ class TestComposerConnection:
         mock_json_ct.side_effect = ["cm-data"]
         composer_connection(self.OPTS)
         mock_ingress_read.assert_called_once_with(
-            "peer-ca-hlf-ca", namespace="ca-namespace", verbose=False
+            "peer-ca-hlf-ca", namespace="ca-namespace"
         )
         mock_cm_read.assert_called_once_with(
-            "connection-secret", "peer-namespace", verbose=False
+            "connection-secret", "peer-namespace"
         )
         mock_json_ct.assert_called_once()
         mock_cm_create.assert_called_once_with(
             {"connection.json": "cm-data"},
             "connection-secret",
-            "peer-namespace",
-            verbose=False,
+            "peer-namespace"
         )
 
     @patch("nephos.composer.install.json_ct")
@@ -93,10 +90,10 @@ class TestComposerConnection:
         mock_cm_read.side_effect = [{"connection.json": "cm-data"}]
         composer_connection(self.OPTS, verbose=True)
         mock_ingress_read.assert_called_once_with(
-            "peer-ca-hlf-ca", namespace="ca-namespace", verbose=True
+            "peer-ca-hlf-ca", namespace="ca-namespace"
         )
         mock_cm_read.assert_called_once_with(
-            "connection-secret", "peer-namespace", verbose=True
+            "connection-secret", "peer-namespace"
         )
         mock_json_ct.assert_not_called()
         mock_cm_create.assert_not_called()
@@ -131,7 +128,7 @@ class TestDeployComposer:
         mock_helm_extra_vars.side_effect = ["extra-vars"]
         deploy_composer(self.OPTS)
         mock_secret_from_file.assert_called_once_with(
-            secret="bna-secret", namespace="peer-namespace", verbose=False
+            secret="bna-secret", namespace="peer-namespace"
         )
         mock_composer_connection.assert_called_once_with(self.OPTS, verbose=False)
         mock_get_version.assert_has_calls([call(self.OPTS, "hl-composer")])
@@ -143,8 +140,7 @@ class TestDeployComposer:
             "hl-composer",
             "hlc",
             "peer-namespace",
-            extra_vars="extra-vars",
-            verbose=False,
+            extra_vars="extra-vars"
         )
         mock_helm_upgrade.assert_not_called()
         mock_helm_check.assert_called_once_with(
@@ -172,7 +168,7 @@ class TestDeployComposer:
         mock_helm_extra_vars.side_effect = ["extra-vars"]
         deploy_composer(self.OPTS, upgrade=True, verbose=True)
         mock_secret_from_file.assert_called_once_with(
-            secret="bna-secret", namespace="peer-namespace", verbose=True
+            secret="bna-secret", namespace="peer-namespace"
         )
         mock_composer_connection.assert_called_once_with(self.OPTS, verbose=True)
         mock_get_version.assert_has_calls([call(self.OPTS, "hl-composer")])
@@ -190,7 +186,7 @@ class TestDeployComposer:
         )
         mock_helm_install.assert_not_called()
         mock_helm_upgrade.assert_called_once_with(
-            "a-repo", "hl-composer", "hlc", extra_vars="extra-vars", verbose=True
+            "a-repo", "hl-composer", "hlc", extra_vars="extra-vars"
         )
         mock_helm_check.assert_called_once_with(
             "hl-composer", "hlc", "peer-namespace", pod_num=3
@@ -223,7 +219,7 @@ class TestSetupCard:
             roles=("a-role", "another-role"),
         )
         mock_get_pod.assert_called_once_with(
-            "peer-namespace", "hlc", "hl-composer", verbose=False
+            "peer-namespace", "hlc", "hl-composer"
         )
         mock_pod.execute.assert_has_calls(
             [
@@ -262,7 +258,7 @@ class TestSetupCard:
             network="a-network",
         )
         mock_get_pod.assert_called_once_with(
-            "peer-namespace", "hlc", "hl-composer", verbose=False
+            "peer-namespace", "hlc", "hl-composer"
         )
         mock_pod.execute.assert_has_calls(
             [
@@ -295,10 +291,10 @@ class TestSetupCard:
             user_name="a-user",
             network="a-network",
             roles=None,
-            verbose=True,
+            verbose=True
         )
         mock_get_pod.assert_called_once_with(
-            "peer-namespace", "hlc", "hl-composer", verbose=True
+            "peer-namespace", "hlc", "hl-composer"
         )
         mock_pod.execute.assert_has_calls(
             [call("composer card list --card a-user@a-network")]
@@ -348,7 +344,7 @@ class TestInstallNetwork:
         mock_get_pod.side_effect = [mock_pod]
         install_network(self.OPTS)
         mock_get_pod.assert_called_once_with(
-            "peer-namespace", "hlc", "hl-composer", verbose=False
+            "peer-namespace", "hlc", "hl-composer"
         )
         mock_pod.execute.assert_has_calls(
             [
@@ -368,7 +364,7 @@ class TestInstallNetwork:
                 call("composer network ping --card an-admin@a-network"),
             ]
         )
-        mock_admin_creds.assert_called_once_with(self.OPTS, "peer_MSP", verbose=False)
+        mock_admin_creds.assert_called_once_with(self.OPTS, "peer_MSP")
 
     @patch("nephos.composer.install.get_helm_pod")
     @patch("nephos.composer.install.admin_creds")
@@ -383,7 +379,7 @@ class TestInstallNetwork:
         mock_get_pod.side_effect = [mock_pod]
         install_network(self.OPTS, verbose=True)
         mock_get_pod.assert_called_once_with(
-            "peer-namespace", "hlc", "hl-composer", verbose=True
+            "peer-namespace", "hlc", "hl-composer"
         )
         mock_pod.execute.assert_has_calls(
             [
@@ -392,4 +388,4 @@ class TestInstallNetwork:
                 call("composer network ping --card an-admin@a-network"),
             ]
         )
-        mock_ca_creds.assert_called_once_with(self.OPTS, "peer_MSP", verbose=True)
+        mock_ca_creds.assert_called_once_with(self.OPTS, "peer_MSP")


### PR DESCRIPTION
The verbose argument was removed from multiple functions with the
commit b6de530d09d5325c31192e27331da8fd3f2c6b60. Seems like the call
for this method wasn't removed from the install.py module. The hotfix
Allows hyperledger composer to be installed.

Signed-off-by: Diego L. Bandin <diego@aid.technology>