### PR TITLE
Travis CI sudo: required no longer is

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 # Based on: https://github.com/LiliC/travis-minikube/blob/minikube-30-kube-1.12/.travis.yml
 
-sudo: required
-
 # We need the systemd for the kubeadm and it's default from 16.04+
 dist: xenial
 


### PR DESCRIPTION
Travis has fully deprecated the sudo tag