### PR TITLE
fix is_orderer_tls_enable function

### DIFF
--- a/nephos/fabric/utils.py
+++ b/nephos/fabric/utils.py
@@ -14,7 +14,6 @@
 
 from glob import glob
 from os import path, rename
-
 from kubernetes.client.rest import ApiException
 
 from nephos.helpers.k8s import Executer, secret_create, secret_read, secret_from_files
@@ -164,8 +163,7 @@ def is_orderer_tls_true(opts):
     """
 
     if "tls" in opts["ordering"]:
-        return opts["ordering"]["tls"]["enable"] == "true"
-    return False
+        return opts["ordering"]["tls"]["enable"] == True
 
 
 def rename_file(directory, name):

--- a/tests/fabric/test_crypto.py
+++ b/tests/fabric/test_crypto.py
@@ -861,7 +861,7 @@ class TestSetupNodes:
         mock_secret_from_files,
     ):
         opts = deepcopy(self.OPTS)
-        opts["ordering"]["tls"] = {"enable": "true", "tls_ca": "ca-tls"}
+        opts["ordering"]["tls"] = {"enable": True, "tls_ca": "ca-tls"}
         mock_get_org_tls_ca_cert.side_effect = ["./alpha_tls"]
         setup_nodes(opts)
         mock_setup_id.assert_has_calls(
@@ -1067,7 +1067,7 @@ class TestTLSToSecrets:
 class TestSetupTLS:
     OPTS = {
         "core": {"dir_crypto": "./crypto"},
-        "ordering": {"tls": {"enable": "true", "tls_ca": "ca-tls"}},
+        "ordering": {"tls": {"enable": True, "tls_ca": "ca-tls"}},
         "cas": {
             "ca-ord": {"namespace": "ca-namespace"},
             "ca-peer": {"namespace": "ca-namespace"},
@@ -1165,7 +1165,7 @@ class TestSetupTLS:
         mock_register_id,
     ):
         opts = deepcopy(self.OPTS)
-        opts["ordering"]["tls"] = {"enable": "true"}
+        opts["ordering"]["tls"] = {"enable": True}
         mock_get_tls_path.side_effect = ["./tls"]
 
         setup_tls(opts, "AlphaMSP", "ord0", "orderer")

--- a/tests/fabric/test_utils.py
+++ b/tests/fabric/test_utils.py
@@ -226,7 +226,7 @@ class TestIsOrdererMSP:
 class TestGetOrgTLSCACert:
     OPTS = {
         "core": {"dir_crypto": "./crypto"},
-        "ordering": {"tls": {"enable": "true", "tls_ca": "ca-tls"}},
+        "ordering": {"tls": {"enable": True, "tls_ca": "ca-tls"}},
     }
 
     @patch("nephos.fabric.utils.glob")
@@ -247,7 +247,7 @@ class TestGetOrgTLSCACert:
     @patch("nephos.fabric.utils.glob")
     def test_get_org_tls_cacert_cryptogen(self, mock_glob):
         opts = deepcopy(self.OPTS)
-        opts["ordering"]["tls"] = {"enable": "true"}
+        opts["ordering"]["tls"] = {"enable": True}
         mock_glob.side_effect = [
             ["./crypto/crypto-config/*Organizations/ns_TLS/tlsca/ca.pem"]
         ]
@@ -258,7 +258,7 @@ class TestGetOrgTLSCACert:
 
 
 class TestIsOrdererTLSTrue:
-    OPTS = {"ordering": {"tls": {"enable": "true", "tls_ca": "ca-tls"}}}
+    OPTS = {"ordering": {"tls": {"enable": True, "tls_ca": "ca-tls"}}}
 
     def test_is_orderer_tls_true(self):
         assert is_orderer_tls_true(opts=self.OPTS)
@@ -277,7 +277,7 @@ class TestIsOrdererTLSTrue:
 class TestGetTLSPath:
     OPTS = {
         "core": {"dir_crypto": "./crypto"},
-        "ordering": {"tls": {"enable": "true", "tls_ca": "ca-tls"}},
+        "ordering": {"tls": {"enable": True, "tls_ca": "ca-tls"}},
     }
 
     @patch("nephos.fabric.utils.glob")
@@ -296,7 +296,7 @@ class TestGetTLSPath:
     @patch("nephos.fabric.utils.glob")
     def test_get_tls_path_cryptogen(self, mock_glob):
         opts = deepcopy(self.OPTS)
-        opts["ordering"]["tls"] = {"enable": "true"}
+        opts["ordering"]["tls"] = {"enable": True}
         mock_glob.side_effect = [
             ["./crypto/crypto-config/ordererOrganizations/ns_MSP/orderers/ord0/tls"]
         ]


### PR DESCRIPTION
currently tls.enable expects value to be a string "true", this PR changes it to a boolean.

Signed-off-by: Inzamam <inzamam.15@cse.mrt.ac.lk>